### PR TITLE
feat: bump grpc-errors module version

### DIFF
--- a/.yarn/versions/bb8ebf95.yml
+++ b/.yarn/versions/bb8ebf95.yml
@@ -1,4 +1,3 @@
 releases:
-  "@atls/nestjs-grpc-errors": patch
   "@atls/nestjs-grpc-http-proxy": patch
   "@atls/nestjs-grpc-playground": patch

--- a/packages/grpc-errors/package.json
+++ b/packages/grpc-errors/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atls/nestjs-grpc-errors",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "BSD-3-Clause",
   "main": "src/index.ts",
   "files": [


### PR DESCRIPTION
Инкрементнировал версию модуля `grpc-errors` через `yarn workspace @atls/nestjs-grpc-errors version patch`.