### PR TITLE
Update kratos dependencies versions

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1105,17 +1105,17 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/kratos/",\
         "packageDependencies": [\
           ["@atls/nestjs-kratos", "workspace:packages/kratos"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/core", "virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5"],\
-          ["@nestjs/testing", "virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5"],\
+          ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
+          ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@nestjs/testing", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
           ["@ory/kratos-client", "npm:0.5.5-alpha.4"],\
-          ["@types/express", "npm:4.17.13"],\
-          ["@types/node", "npm:17.0.18"],\
-          ["express", "npm:4.17.3"],\
-          ["get-port", "npm:5.1.1"],\
+          ["@types/express", "npm:4.17.14"],\
+          ["@types/node", "npm:20.6.2"],\
+          ["express", "npm:4.18.2"],\
+          ["get-port", "npm:7.0.0"],\
           ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:7.5.4"],\
-          ["supertest", "npm:6.2.2"]\
+          ["rxjs", "npm:7.8.1"],\
+          ["supertest", "npm:6.3.3"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -1125,15 +1125,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/logger/",\
         "packageDependencies": [\
           ["@atls/nestjs-logger", "workspace:packages/logger"],\
-          ["@atls/logger", "npm:0.0.2"],\
-          ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
-          ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
-          ["@nestjs/testing", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
-          ["@types/node", "npm:20.6.2"],\
-          ["get-port", "npm:7.0.0"],\
+          ["@atls/logger", "npm:0.0.1"],\
+          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
+          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
+          ["@nestjs/testing", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
+          ["@types/node", "npm:17.0.18"],\
+          ["get-port", "npm:5.1.1"],\
           ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:7.8.1"],\
-          ["supertest", "npm:6.3.3"],\
+          ["rxjs", "npm:7.5.4"],\
+          ["supertest", "npm:6.2.2"],\
           ["typeorm", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:0.2.45"]\
         ],\
         "linkType": "SOFT"\
@@ -1164,20 +1164,20 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@atls-nestjs-typesense-virtual-d88920d272/1/packages/typesense/",\
         "packageDependencies": [\
           ["@atls/nestjs-typesense", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#workspace:packages/typesense"],\
-          ["@atls/logger", "npm:0.0.2"],\
+          ["@atls/logger", "npm:0.0.1"],\
           ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
           ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
-          ["@nestjs/testing", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@nestjs/testing", "virtual:d88920d272f632ec694c1d42aa196e89d8ca2df9a80a6ea52df5924cbc4e4e62b12fb010cf8727fd07105e539ebb4e39ff3c8d696ed342a636fbaffac393a3b8#npm:8.0.5"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
           ["@types/reflect-metadata", null],\
           ["@types/rxjs", null],\
           ["@types/typesense", null],\
           ["decamelize", "npm:5.0.0"],\
-          ["get-port", "npm:7.0.0"],\
+          ["get-port", "npm:5.1.1"],\
           ["reflect-metadata", "npm:0.1.13"],\
           ["rxjs", "npm:7.8.1"],\
-          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0"]\
+          ["typesense", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.15.0"]\
         ],\
         "packagePeers": [\
           "@nestjs/common",\
@@ -1197,15 +1197,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/typesense/",\
         "packageDependencies": [\
           ["@atls/nestjs-typesense", "workspace:packages/typesense"],\
-          ["@atls/logger", "npm:0.0.2"],\
-          ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
-          ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
-          ["@nestjs/testing", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@atls/logger", "npm:0.0.1"],\
+          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
+          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
+          ["@nestjs/testing", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
           ["decamelize", "npm:5.0.0"],\
-          ["get-port", "npm:7.0.0"],\
+          ["get-port", "npm:5.1.1"],\
           ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:7.8.1"],\
-          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0"]\
+          ["rxjs", "npm:7.5.4"],\
+          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.14.0"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -1227,7 +1227,7 @@ const RAW_RUNTIME_STATE =
           ["sqlite3", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:5.1.6"],\
           ["testcontainers", "npm:10.2.1"],\
           ["typeorm", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.2.45"],\
-          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0"]\
+          ["typesense", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.15.0"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -4674,7 +4674,7 @@ const RAW_RUNTIME_STATE =
         "linkType": "SOFT"\
       }],\
       ["npm:8.0.5", {\
-        "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-cc780be602/node_modules/@nestjs/core/",\
+        "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-7f1eebd9b5/node_modules/@nestjs/core/",\
         "packageDependencies": [\
           ["@nestjs/core", "npm:8.0.5"]\
         ],\
@@ -4847,6 +4847,45 @@ const RAW_RUNTIME_STATE =
           ["@nestjs/common", "virtual:24d6edb51dd7c48a91903ce08eae93303ffdf43623b1ec0dd7ef866de2a2121e0e1c9967d639267ee0db80cfdb7ea05c0880e3d5dffa84ab9bb6eb142bdeba2d#npm:8.0.6"],\
           ["@nestjs/microservices", null],\
           ["@nestjs/platform-express", "virtual:99750a1284cfae369097b38231199bb0df007f67704b407d154592c1903787c905f9bcef3ba25c2e8ed4957ac4d7a2f4a2b14849230ff52e0c1bac86ea9e2606#npm:7.6.15"],\
+          ["@nestjs/websockets", null],\
+          ["@nuxtjs/opencollective", "npm:0.3.2"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__microservices", null],\
+          ["@types/nestjs__platform-express", null],\
+          ["@types/nestjs__websockets", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["fast-safe-stringify", "npm:2.0.8"],\
+          ["iterare", "npm:1.2.1"],\
+          ["object-hash", "npm:2.2.0"],\
+          ["path-to-regexp", "npm:3.2.0"],\
+          ["reflect-metadata", "npm:0.1.13"],\
+          ["rxjs", "npm:7.5.4"],\
+          ["tslib", "npm:2.3.0"],\
+          ["uuid", "npm:8.3.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/microservices",\
+          "@nestjs/websockets",\
+          "@types/nestjs__common",\
+          "@types/nestjs__microservices",\
+          "@types/nestjs__platform-express",\
+          "@types/nestjs__websockets",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5", {\
+        "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-7f1eebd9b5/node_modules/@nestjs/core/",\
+        "packageDependencies": [\
+          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
+          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
+          ["@nestjs/microservices", null],\
+          ["@nestjs/platform-express", "virtual:7f1eebd9b55f2cce268e906d9268599de0b72ccfed7a703a908df7338a74c7ea84e03c9bc7061d7ac8e79dbd8dc82d754fc340d52b53ef6e552102e772f2b3ca#npm:7.6.15"],\
           ["@nestjs/websockets", null],\
           ["@nuxtjs/opencollective", "npm:0.3.2"],\
           ["@types/nestjs__common", null],\
@@ -5094,45 +5133,6 @@ const RAW_RUNTIME_STATE =
           ["rxjs", "npm:7.8.1"],\
           ["tslib", "npm:2.6.1"],\
           ["uid", "npm:2.0.2"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/microservices",\
-          "@nestjs/websockets",\
-          "@types/nestjs__common",\
-          "@types/nestjs__microservices",\
-          "@types/nestjs__platform-express",\
-          "@types/nestjs__websockets",\
-          "@types/reflect-metadata",\
-          "@types/rxjs",\
-          "reflect-metadata",\
-          "rxjs"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5", {\
-        "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-cc780be602/node_modules/@nestjs/core/",\
-        "packageDependencies": [\
-          ["@nestjs/core", "virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/microservices", null],\
-          ["@nestjs/platform-express", "virtual:cc780be602631d78bb5cd9088932a2f4b37f6baeda0e76e49d3353d6b334d02b36b9726a635e3f8fb1802034619bacb6fe4007b16724e2d93cce439d667e4543#npm:7.6.15"],\
-          ["@nestjs/websockets", null],\
-          ["@nuxtjs/opencollective", "npm:0.3.2"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__microservices", null],\
-          ["@types/nestjs__platform-express", null],\
-          ["@types/nestjs__websockets", null],\
-          ["@types/reflect-metadata", null],\
-          ["@types/rxjs", null],\
-          ["fast-safe-stringify", "npm:2.0.8"],\
-          ["iterare", "npm:1.2.1"],\
-          ["object-hash", "npm:2.2.0"],\
-          ["path-to-regexp", "npm:3.2.0"],\
-          ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:7.5.4"],\
-          ["tslib", "npm:2.3.0"],\
-          ["uuid", "npm:8.3.2"]\
         ],\
         "packagePeers": [\
           "@nestjs/common",\
@@ -6253,6 +6253,28 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["virtual:7f1eebd9b55f2cce268e906d9268599de0b72ccfed7a703a908df7338a74c7ea84e03c9bc7061d7ac8e79dbd8dc82d754fc340d52b53ef6e552102e772f2b3ca#npm:7.6.15", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-2fa1051d42/4/.yarn/berry/cache/@nestjs-platform-express-npm-7.6.15-44f82e81dd-9.zip/node_modules/@nestjs/platform-express/",\
+        "packageDependencies": [\
+          ["@nestjs/platform-express", "virtual:7f1eebd9b55f2cce268e906d9268599de0b72ccfed7a703a908df7338a74c7ea84e03c9bc7061d7ac8e79dbd8dc82d754fc340d52b53ef6e552102e772f2b3ca#npm:7.6.15"],\
+          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
+          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["body-parser", "npm:1.19.0"],\
+          ["cors", "npm:2.8.5"],\
+          ["express", "npm:4.17.1"],\
+          ["multer", "npm:1.4.2"],\
+          ["tslib", "npm:2.1.0"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:822002498fbdad2cac34236477296e78234b5bfa944b72062df821cdd6947ac1abd3e630077746eb90a5920c93f2ee1f94fbbe89898088370dcc63c0f4d41265#npm:7.6.15", {\
         "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-01399ecee3/4/.yarn/berry/cache/@nestjs-platform-express-npm-7.6.15-44f82e81dd-9.zip/node_modules/@nestjs/platform-express/",\
         "packageDependencies": [\
@@ -6347,28 +6369,6 @@ const RAW_RUNTIME_STATE =
           ["@nestjs/platform-express", "virtual:be6c1e878359ea06612510fb16fa7eaff7329a7433cd1cb81c9914313c6b58b917fdf6a4c2ba68b280b4217ef89076f3854c5ff4aa8c4f1bb98413e60304558b#npm:7.6.15"],\
           ["@nestjs/common", "virtual:a2160e3b2e27c63b1b84c6435ca41f4eb71e35a78ebc7c1ffc239ded29b61466bf16d9a78f6ac2fc343b6bf7363917f14146da61a234e2285c5eecea1ecc2202#npm:10.1.3"],\
           ["@nestjs/core", "virtual:a2160e3b2e27c63b1b84c6435ca41f4eb71e35a78ebc7c1ffc239ded29b61466bf16d9a78f6ac2fc343b6bf7363917f14146da61a234e2285c5eecea1ecc2202#npm:10.1.3"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__core", null],\
-          ["body-parser", "npm:1.19.0"],\
-          ["cors", "npm:2.8.5"],\
-          ["express", "npm:4.17.1"],\
-          ["multer", "npm:1.4.2"],\
-          ["tslib", "npm:2.1.0"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/core",\
-          "@types/nestjs__common",\
-          "@types/nestjs__core"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:cc780be602631d78bb5cd9088932a2f4b37f6baeda0e76e49d3353d6b334d02b36b9726a635e3f8fb1802034619bacb6fe4007b16724e2d93cce439d667e4543#npm:7.6.15", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-e130666d62/4/.yarn/berry/cache/@nestjs-platform-express-npm-7.6.15-44f82e81dd-9.zip/node_modules/@nestjs/platform-express/",\
-        "packageDependencies": [\
-          ["@nestjs/platform-express", "virtual:cc780be602631d78bb5cd9088932a2f4b37f6baeda0e76e49d3353d6b334d02b36b9726a635e3f8fb1802034619bacb6fe4007b16724e2d93cce439d667e4543#npm:7.6.15"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/core", "virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
           ["body-parser", "npm:1.19.0"],\
@@ -6531,6 +6531,32 @@ const RAW_RUNTIME_STATE =
           ["@nestjs/core", "virtual:24d6edb51dd7c48a91903ce08eae93303ffdf43623b1ec0dd7ef866de2a2121e0e1c9967d639267ee0db80cfdb7ea05c0880e3d5dffa84ab9bb6eb142bdeba2d#npm:8.0.6"],\
           ["@nestjs/microservices", null],\
           ["@nestjs/platform-express", "virtual:99750a1284cfae369097b38231199bb0df007f67704b407d154592c1903787c905f9bcef3ba25c2e8ed4957ac4d7a2f4a2b14849230ff52e0c1bac86ea9e2606#npm:7.6.15"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/nestjs__microservices", null],\
+          ["@types/nestjs__platform-express", null],\
+          ["optional", "npm:0.1.4"],\
+          ["tslib", "npm:2.3.0"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@nestjs/microservices",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/nestjs__microservices",\
+          "@types/nestjs__platform-express"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-a14ee4731b/4/.yarn/berry/cache/@nestjs-testing-npm-8.0.5-609af03979-9.zip/node_modules/@nestjs/testing/",\
+        "packageDependencies": [\
+          ["@nestjs/testing", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
+          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
+          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
+          ["@nestjs/microservices", null],\
+          ["@nestjs/platform-express", "virtual:7f1eebd9b55f2cce268e906d9268599de0b72ccfed7a703a908df7338a74c7ea84e03c9bc7061d7ac8e79dbd8dc82d754fc340d52b53ef6e552102e772f2b3ca#npm:7.6.15"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
           ["@types/nestjs__microservices", null],\
@@ -6802,32 +6828,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-fbc4a9d28f/4/.yarn/berry/cache/@nestjs-testing-npm-8.0.5-609af03979-9.zip/node_modules/@nestjs/testing/",\
-        "packageDependencies": [\
-          ["@nestjs/testing", "virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/core", "virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5"],\
-          ["@nestjs/microservices", null],\
-          ["@nestjs/platform-express", "virtual:cc780be602631d78bb5cd9088932a2f4b37f6baeda0e76e49d3353d6b334d02b36b9726a635e3f8fb1802034619bacb6fe4007b16724e2d93cce439d667e4543#npm:7.6.15"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__core", null],\
-          ["@types/nestjs__microservices", null],\
-          ["@types/nestjs__platform-express", null],\
-          ["optional", "npm:0.1.4"],\
-          ["tslib", "npm:2.3.0"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/core",\
-          "@nestjs/microservices",\
-          "@types/nestjs__common",\
-          "@types/nestjs__core",\
-          "@types/nestjs__microservices",\
-          "@types/nestjs__platform-express"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:d2468a0399c67d69d170ccaedf684d84187afc1108a5d5c03b908d807e2604b1dd3e9182f827a3c93c64ddfa4f4d650fd32e50961e5058754271991572988446#npm:10.2.1", {\
         "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-69edfa81fb/4/.yarn/berry/cache/@nestjs-testing-npm-10.2.1-b3528ca2f8-9.zip/node_modules/@nestjs/testing/",\
         "packageDependencies": [\
@@ -6841,6 +6841,32 @@ const RAW_RUNTIME_STATE =
           ["@types/nestjs__microservices", null],\
           ["@types/nestjs__platform-express", null],\
           ["tslib", "npm:2.6.1"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@nestjs/microservices",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/nestjs__microservices",\
+          "@types/nestjs__platform-express"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:d88920d272f632ec694c1d42aa196e89d8ca2df9a80a6ea52df5924cbc4e4e62b12fb010cf8727fd07105e539ebb4e39ff3c8d696ed342a636fbaffac393a3b8#npm:8.0.5", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-727c5dc7cf/4/.yarn/berry/cache/@nestjs-testing-npm-8.0.5-609af03979-9.zip/node_modules/@nestjs/testing/",\
+        "packageDependencies": [\
+          ["@nestjs/testing", "virtual:d88920d272f632ec694c1d42aa196e89d8ca2df9a80a6ea52df5924cbc4e4e62b12fb010cf8727fd07105e539ebb4e39ff3c8d696ed342a636fbaffac393a3b8#npm:8.0.5"],\
+          ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
+          ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@nestjs/microservices", null],\
+          ["@nestjs/platform-express", "virtual:461a90360ead340e1a944146d1d018ac4bd8c511929ec079da2de92a8e8fc3a176cb36ae46210674875bea223add6c245c270ecdc18a0665e74ff48987490746#npm:7.6.15"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/nestjs__microservices", null],\
+          ["@types/nestjs__platform-express", null],\
+          ["optional", "npm:0.1.4"],\
+          ["tslib", "npm:2.3.0"]\
         ],\
         "packagePeers": [\
           "@nestjs/common",\
@@ -7424,6 +7450,17 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../.yarn/berry/cache/@types-express-npm-4.17.13-0e12fe9c24-9.zip/node_modules/@types/express/",\
         "packageDependencies": [\
           ["@types/express", "npm:4.17.13"],\
+          ["@types/body-parser", "npm:1.19.0"],\
+          ["@types/express-serve-static-core", "npm:4.17.24"],\
+          ["@types/qs", "npm:6.9.5"],\
+          ["@types/serve-static", "npm:1.13.8"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:4.17.14", {\
+        "packageLocation": "../../../.yarn/berry/cache/@types-express-npm-4.17.14-076e1b4711-9.zip/node_modules/@types/express/",\
+        "packageDependencies": [\
+          ["@types/express", "npm:4.17.14"],\
           ["@types/body-parser", "npm:1.19.0"],\
           ["@types/express-serve-static-core", "npm:4.17.24"],\
           ["@types/qs", "npm:6.9.5"],\
@@ -9614,23 +9651,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:1.19.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/body-parser-npm-1.19.2-33c5bfcb21-9.zip/node_modules/body-parser/",\
-        "packageDependencies": [\
-          ["body-parser", "npm:1.19.2"],\
-          ["bytes", "npm:3.1.2"],\
-          ["content-type", "npm:1.0.4"],\
-          ["debug", "virtual:759fd14db92b54abdb7afb3d21dbf8d50f1a5c59c96cd3f963ce3e3ed063bdb801142fae5f01cc81fb79f7ddc13b7c31a9deb9d5a9cfa48ec107f83de8f7f40e#npm:2.6.9"],\
-          ["depd", "npm:1.1.2"],\
-          ["http-errors", "npm:1.8.1"],\
-          ["iconv-lite", "npm:0.4.24"],\
-          ["on-finished", "npm:2.3.0"],\
-          ["qs", "npm:6.9.7"],\
-          ["raw-body", "npm:2.4.3"],\
-          ["type-is", "npm:1.6.18"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:1.20.1", {\
         "packageLocation": "../../../.yarn/berry/cache/body-parser-npm-1.20.1-759fd14db9-9.zip/node_modules/body-parser/",\
         "packageDependencies": [\
@@ -10451,13 +10471,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../.yarn/berry/cache/cookie-npm-0.4.0-4b3d629e45-9.zip/node_modules/cookie/",\
         "packageDependencies": [\
           ["cookie", "npm:0.4.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:0.4.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/cookie-npm-0.4.2-7761894d5f-9.zip/node_modules/cookie/",\
-        "packageDependencies": [\
-          ["cookie", "npm:0.4.2"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -11732,43 +11745,6 @@ const RAW_RUNTIME_STATE =
           ["send", "npm:0.17.1"],\
           ["serve-static", "npm:1.14.1"],\
           ["setprototypeof", "npm:1.1.1"],\
-          ["statuses", "npm:1.5.0"],\
-          ["type-is", "npm:1.6.18"],\
-          ["utils-merge", "npm:1.0.1"],\
-          ["vary", "npm:1.1.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:4.17.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/express-npm-4.17.3-889f836f0d-9.zip/node_modules/express/",\
-        "packageDependencies": [\
-          ["express", "npm:4.17.3"],\
-          ["accepts", "npm:1.3.8"],\
-          ["array-flatten", "npm:1.1.1"],\
-          ["body-parser", "npm:1.19.2"],\
-          ["content-disposition", "npm:0.5.4"],\
-          ["content-type", "npm:1.0.4"],\
-          ["cookie", "npm:0.4.2"],\
-          ["cookie-signature", "npm:1.0.6"],\
-          ["debug", "virtual:759fd14db92b54abdb7afb3d21dbf8d50f1a5c59c96cd3f963ce3e3ed063bdb801142fae5f01cc81fb79f7ddc13b7c31a9deb9d5a9cfa48ec107f83de8f7f40e#npm:2.6.9"],\
-          ["depd", "npm:1.1.2"],\
-          ["encodeurl", "npm:1.0.2"],\
-          ["escape-html", "npm:1.0.3"],\
-          ["etag", "npm:1.8.1"],\
-          ["finalhandler", "npm:1.1.2"],\
-          ["fresh", "npm:0.5.2"],\
-          ["merge-descriptors", "npm:1.0.1"],\
-          ["methods", "npm:1.1.2"],\
-          ["on-finished", "npm:2.3.0"],\
-          ["parseurl", "npm:1.3.3"],\
-          ["path-to-regexp", "npm:0.1.7"],\
-          ["proxy-addr", "npm:2.0.7"],\
-          ["qs", "npm:6.9.7"],\
-          ["range-parser", "npm:1.2.1"],\
-          ["safe-buffer", "npm:5.2.1"],\
-          ["send", "npm:0.17.2"],\
-          ["serve-static", "npm:1.14.2"],\
-          ["setprototypeof", "npm:1.2.0"],\
           ["statuses", "npm:1.5.0"],\
           ["type-is", "npm:1.6.18"],\
           ["utils-merge", "npm:1.0.1"],\
@@ -13214,18 +13190,6 @@ const RAW_RUNTIME_STATE =
           ["setprototypeof", "npm:1.2.0"],\
           ["statuses", "npm:1.5.0"],\
           ["toidentifier", "npm:1.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:1.8.1", {\
-        "packageLocation": "../../../.yarn/berry/cache/http-errors-npm-1.8.1-fb60d9f6ae-9.zip/node_modules/http-errors/",\
-        "packageDependencies": [\
-          ["http-errors", "npm:1.8.1"],\
-          ["depd", "npm:1.1.2"],\
-          ["inherits", "npm:2.0.4"],\
-          ["setprototypeof", "npm:1.2.0"],\
-          ["statuses", "npm:1.5.0"],\
-          ["toidentifier", "npm:1.0.1"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -16664,13 +16628,6 @@ const RAW_RUNTIME_STATE =
           ["qs", "npm:6.9.3"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:6.9.7", {\
-        "packageLocation": "../../../.yarn/berry/cache/qs-npm-6.9.7-3f3fa3ac7b-9.zip/node_modules/qs/",\
-        "packageDependencies": [\
-          ["qs", "npm:6.9.7"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["queue-tick", [\
@@ -16707,17 +16664,6 @@ const RAW_RUNTIME_STATE =
           ["raw-body", "npm:2.4.0"],\
           ["bytes", "npm:3.1.0"],\
           ["http-errors", "npm:1.7.2"],\
-          ["iconv-lite", "npm:0.4.24"],\
-          ["unpipe", "npm:1.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:2.4.3", {\
-        "packageLocation": "../../../.yarn/berry/cache/raw-body-npm-2.4.3-8e0a306e17-9.zip/node_modules/raw-body/",\
-        "packageDependencies": [\
-          ["raw-body", "npm:2.4.3"],\
-          ["bytes", "npm:3.1.2"],\
-          ["http-errors", "npm:1.8.1"],\
           ["iconv-lite", "npm:0.4.24"],\
           ["unpipe", "npm:1.0.0"]\
         ],\
@@ -17179,26 +17125,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["npm:0.17.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/send-npm-0.17.2-73a3dbeba6-9.zip/node_modules/send/",\
-        "packageDependencies": [\
-          ["send", "npm:0.17.2"],\
-          ["debug", "virtual:759fd14db92b54abdb7afb3d21dbf8d50f1a5c59c96cd3f963ce3e3ed063bdb801142fae5f01cc81fb79f7ddc13b7c31a9deb9d5a9cfa48ec107f83de8f7f40e#npm:2.6.9"],\
-          ["depd", "npm:1.1.2"],\
-          ["destroy", "npm:1.0.4"],\
-          ["encodeurl", "npm:1.0.2"],\
-          ["escape-html", "npm:1.0.3"],\
-          ["etag", "npm:1.8.1"],\
-          ["fresh", "npm:0.5.2"],\
-          ["http-errors", "npm:1.8.1"],\
-          ["mime", "npm:1.6.0"],\
-          ["ms", "npm:2.1.3"],\
-          ["on-finished", "npm:2.3.0"],\
-          ["range-parser", "npm:1.2.1"],\
-          ["statuses", "npm:1.5.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:0.18.0", {\
         "packageLocation": "../../../.yarn/berry/cache/send-npm-0.18.0-faadf6353f-9.zip/node_modules/send/",\
         "packageDependencies": [\
@@ -17241,17 +17167,6 @@ const RAW_RUNTIME_STATE =
           ["escape-html", "npm:1.0.3"],\
           ["parseurl", "npm:1.3.3"],\
           ["send", "npm:0.17.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:1.14.2", {\
-        "packageLocation": "../../../.yarn/berry/cache/serve-static-npm-1.14.2-3ce50bb5ff-9.zip/node_modules/serve-static/",\
-        "packageDependencies": [\
-          ["serve-static", "npm:1.14.2"],\
-          ["encodeurl", "npm:1.0.2"],\
-          ["escape-html", "npm:1.0.3"],\
-          ["parseurl", "npm:1.3.3"],\
-          ["send", "npm:0.17.2"]\
         ],\
         "linkType": "HARD"\
       }],\
@@ -18930,6 +18845,13 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["typesense", [\
+      ["npm:0.14.0", {\
+        "packageLocation": "../../../.yarn/berry/cache/typesense-npm-0.14.0-016a360d01-9.zip/node_modules/typesense/",\
+        "packageDependencies": [\
+          ["typesense", "npm:0.14.0"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
       ["npm:0.15.0", {\
         "packageLocation": "../../../.yarn/berry/cache/typesense-npm-0.15.0-1d71e88629-9.zip/node_modules/typesense/",\
         "packageDependencies": [\
@@ -18937,10 +18859,24 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0", {\
-        "packageLocation": "./.yarn/__virtual__/typesense-virtual-d325855425/4/.yarn/berry/cache/typesense-npm-0.15.0-1d71e88629-9.zip/node_modules/typesense/",\
+      ["virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.14.0", {\
+        "packageLocation": "./.yarn/__virtual__/typesense-virtual-6b74f9f908/4/.yarn/berry/cache/typesense-npm-0.14.0-016a360d01-9.zip/node_modules/typesense/",\
         "packageDependencies": [\
-          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0"],\
+          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.14.0"],\
+          ["@babel/runtime", "npm:7.14.8"],\
+          ["@types/babel__runtime", null],\
+          ["axios", "npm:0.21.1"],\
+          ["loglevel", "npm:1.7.1"]\
+        ],\
+        "packagePeers": [\
+          "@types/babel__runtime"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.15.0", {\
+        "packageLocation": "./.yarn/__virtual__/typesense-virtual-1251740d93/4/.yarn/berry/cache/typesense-npm-0.15.0-1d71e88629-9.zip/node_modules/typesense/",\
+        "packageDependencies": [\
+          ["typesense", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.15.0"],\
           ["@babel/runtime", "npm:7.14.8"],\
           ["@types/babel__runtime", null],\
           ["axios", "npm:0.21.1"],\

--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1125,15 +1125,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/logger/",\
         "packageDependencies": [\
           ["@atls/nestjs-logger", "workspace:packages/logger"],\
-          ["@atls/logger", "npm:0.0.1"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
-          ["@nestjs/testing", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
-          ["@types/node", "npm:17.0.18"],\
-          ["get-port", "npm:5.1.1"],\
+          ["@atls/logger", "npm:0.0.2"],\
+          ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
+          ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@nestjs/testing", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@types/node", "npm:20.6.2"],\
+          ["get-port", "npm:7.0.0"],\
           ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:7.5.4"],\
-          ["supertest", "npm:6.2.2"],\
+          ["rxjs", "npm:7.8.1"],\
+          ["supertest", "npm:6.3.3"],\
           ["typeorm", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:0.2.45"]\
         ],\
         "linkType": "SOFT"\
@@ -1164,20 +1164,20 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./.yarn/__virtual__/@atls-nestjs-typesense-virtual-d88920d272/1/packages/typesense/",\
         "packageDependencies": [\
           ["@atls/nestjs-typesense", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#workspace:packages/typesense"],\
-          ["@atls/logger", "npm:0.0.1"],\
+          ["@atls/logger", "npm:0.0.2"],\
           ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
           ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
-          ["@nestjs/testing", "virtual:d88920d272f632ec694c1d42aa196e89d8ca2df9a80a6ea52df5924cbc4e4e62b12fb010cf8727fd07105e539ebb4e39ff3c8d696ed342a636fbaffac393a3b8#npm:8.0.5"],\
+          ["@nestjs/testing", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
           ["@types/reflect-metadata", null],\
           ["@types/rxjs", null],\
           ["@types/typesense", null],\
           ["decamelize", "npm:5.0.0"],\
-          ["get-port", "npm:5.1.1"],\
+          ["get-port", "npm:7.0.0"],\
           ["reflect-metadata", "npm:0.1.13"],\
           ["rxjs", "npm:7.8.1"],\
-          ["typesense", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.15.0"]\
+          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0"]\
         ],\
         "packagePeers": [\
           "@nestjs/common",\
@@ -1197,15 +1197,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/typesense/",\
         "packageDependencies": [\
           ["@atls/nestjs-typesense", "workspace:packages/typesense"],\
-          ["@atls/logger", "npm:0.0.1"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
-          ["@nestjs/testing", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
+          ["@atls/logger", "npm:0.0.2"],\
+          ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
+          ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@nestjs/testing", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
           ["decamelize", "npm:5.0.0"],\
-          ["get-port", "npm:5.1.1"],\
+          ["get-port", "npm:7.0.0"],\
           ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:7.5.4"],\
-          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.14.0"]\
+          ["rxjs", "npm:7.8.1"],\
+          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -1227,7 +1227,7 @@ const RAW_RUNTIME_STATE =
           ["sqlite3", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:5.1.6"],\
           ["testcontainers", "npm:10.2.1"],\
           ["typeorm", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.2.45"],\
-          ["typesense", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.15.0"]\
+          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0"]\
         ],\
         "linkType": "SOFT"\
       }]\
@@ -4674,7 +4674,7 @@ const RAW_RUNTIME_STATE =
         "linkType": "SOFT"\
       }],\
       ["npm:8.0.5", {\
-        "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-7f1eebd9b5/node_modules/@nestjs/core/",\
+        "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-61114c609d/node_modules/@nestjs/core/",\
         "packageDependencies": [\
           ["@nestjs/core", "npm:8.0.5"]\
         ],\
@@ -4847,45 +4847,6 @@ const RAW_RUNTIME_STATE =
           ["@nestjs/common", "virtual:24d6edb51dd7c48a91903ce08eae93303ffdf43623b1ec0dd7ef866de2a2121e0e1c9967d639267ee0db80cfdb7ea05c0880e3d5dffa84ab9bb6eb142bdeba2d#npm:8.0.6"],\
           ["@nestjs/microservices", null],\
           ["@nestjs/platform-express", "virtual:99750a1284cfae369097b38231199bb0df007f67704b407d154592c1903787c905f9bcef3ba25c2e8ed4957ac4d7a2f4a2b14849230ff52e0c1bac86ea9e2606#npm:7.6.15"],\
-          ["@nestjs/websockets", null],\
-          ["@nuxtjs/opencollective", "npm:0.3.2"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__microservices", null],\
-          ["@types/nestjs__platform-express", null],\
-          ["@types/nestjs__websockets", null],\
-          ["@types/reflect-metadata", null],\
-          ["@types/rxjs", null],\
-          ["fast-safe-stringify", "npm:2.0.8"],\
-          ["iterare", "npm:1.2.1"],\
-          ["object-hash", "npm:2.2.0"],\
-          ["path-to-regexp", "npm:3.2.0"],\
-          ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:7.5.4"],\
-          ["tslib", "npm:2.3.0"],\
-          ["uuid", "npm:8.3.2"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/microservices",\
-          "@nestjs/websockets",\
-          "@types/nestjs__common",\
-          "@types/nestjs__microservices",\
-          "@types/nestjs__platform-express",\
-          "@types/nestjs__websockets",\
-          "@types/reflect-metadata",\
-          "@types/rxjs",\
-          "reflect-metadata",\
-          "rxjs"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5", {\
-        "packageLocation": "./.yarn/unplugged/@nestjs-core-virtual-7f1eebd9b5/node_modules/@nestjs/core/",\
-        "packageDependencies": [\
-          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/microservices", null],\
-          ["@nestjs/platform-express", "virtual:7f1eebd9b55f2cce268e906d9268599de0b72ccfed7a703a908df7338a74c7ea84e03c9bc7061d7ac8e79dbd8dc82d754fc340d52b53ef6e552102e772f2b3ca#npm:7.6.15"],\
           ["@nestjs/websockets", null],\
           ["@nuxtjs/opencollective", "npm:0.3.2"],\
           ["@types/nestjs__common", null],\
@@ -6253,28 +6214,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:7f1eebd9b55f2cce268e906d9268599de0b72ccfed7a703a908df7338a74c7ea84e03c9bc7061d7ac8e79dbd8dc82d754fc340d52b53ef6e552102e772f2b3ca#npm:7.6.15", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-2fa1051d42/4/.yarn/berry/cache/@nestjs-platform-express-npm-7.6.15-44f82e81dd-9.zip/node_modules/@nestjs/platform-express/",\
-        "packageDependencies": [\
-          ["@nestjs/platform-express", "virtual:7f1eebd9b55f2cce268e906d9268599de0b72ccfed7a703a908df7338a74c7ea84e03c9bc7061d7ac8e79dbd8dc82d754fc340d52b53ef6e552102e772f2b3ca#npm:7.6.15"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__core", null],\
-          ["body-parser", "npm:1.19.0"],\
-          ["cors", "npm:2.8.5"],\
-          ["express", "npm:4.17.1"],\
-          ["multer", "npm:1.4.2"],\
-          ["tslib", "npm:2.1.0"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/core",\
-          "@types/nestjs__common",\
-          "@types/nestjs__core"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:822002498fbdad2cac34236477296e78234b5bfa944b72062df821cdd6947ac1abd3e630077746eb90a5920c93f2ee1f94fbbe89898088370dcc63c0f4d41265#npm:7.6.15", {\
         "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-01399ecee3/4/.yarn/berry/cache/@nestjs-platform-express-npm-7.6.15-44f82e81dd-9.zip/node_modules/@nestjs/platform-express/",\
         "packageDependencies": [\
@@ -6531,32 +6470,6 @@ const RAW_RUNTIME_STATE =
           ["@nestjs/core", "virtual:24d6edb51dd7c48a91903ce08eae93303ffdf43623b1ec0dd7ef866de2a2121e0e1c9967d639267ee0db80cfdb7ea05c0880e3d5dffa84ab9bb6eb142bdeba2d#npm:8.0.6"],\
           ["@nestjs/microservices", null],\
           ["@nestjs/platform-express", "virtual:99750a1284cfae369097b38231199bb0df007f67704b407d154592c1903787c905f9bcef3ba25c2e8ed4957ac4d7a2f4a2b14849230ff52e0c1bac86ea9e2606#npm:7.6.15"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__core", null],\
-          ["@types/nestjs__microservices", null],\
-          ["@types/nestjs__platform-express", null],\
-          ["optional", "npm:0.1.4"],\
-          ["tslib", "npm:2.3.0"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/core",\
-          "@nestjs/microservices",\
-          "@types/nestjs__common",\
-          "@types/nestjs__core",\
-          "@types/nestjs__microservices",\
-          "@types/nestjs__platform-express"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-a14ee4731b/4/.yarn/berry/cache/@nestjs-testing-npm-8.0.5-609af03979-9.zip/node_modules/@nestjs/testing/",\
-        "packageDependencies": [\
-          ["@nestjs/testing", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/core", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:8.0.5"],\
-          ["@nestjs/microservices", null],\
-          ["@nestjs/platform-express", "virtual:7f1eebd9b55f2cce268e906d9268599de0b72ccfed7a703a908df7338a74c7ea84e03c9bc7061d7ac8e79dbd8dc82d754fc340d52b53ef6e552102e772f2b3ca#npm:7.6.15"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
           ["@types/nestjs__microservices", null],\
@@ -6841,32 +6754,6 @@ const RAW_RUNTIME_STATE =
           ["@types/nestjs__microservices", null],\
           ["@types/nestjs__platform-express", null],\
           ["tslib", "npm:2.6.1"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/core",\
-          "@nestjs/microservices",\
-          "@types/nestjs__common",\
-          "@types/nestjs__core",\
-          "@types/nestjs__microservices",\
-          "@types/nestjs__platform-express"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:d88920d272f632ec694c1d42aa196e89d8ca2df9a80a6ea52df5924cbc4e4e62b12fb010cf8727fd07105e539ebb4e39ff3c8d696ed342a636fbaffac393a3b8#npm:8.0.5", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-727c5dc7cf/4/.yarn/berry/cache/@nestjs-testing-npm-8.0.5-609af03979-9.zip/node_modules/@nestjs/testing/",\
-        "packageDependencies": [\
-          ["@nestjs/testing", "virtual:d88920d272f632ec694c1d42aa196e89d8ca2df9a80a6ea52df5924cbc4e4e62b12fb010cf8727fd07105e539ebb4e39ff3c8d696ed342a636fbaffac393a3b8#npm:8.0.5"],\
-          ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
-          ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
-          ["@nestjs/microservices", null],\
-          ["@nestjs/platform-express", "virtual:461a90360ead340e1a944146d1d018ac4bd8c511929ec079da2de92a8e8fc3a176cb36ae46210674875bea223add6c245c270ecdc18a0665e74ff48987490746#npm:7.6.15"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__core", null],\
-          ["@types/nestjs__microservices", null],\
-          ["@types/nestjs__platform-express", null],\
-          ["optional", "npm:0.1.4"],\
-          ["tslib", "npm:2.3.0"]\
         ],\
         "packagePeers": [\
           "@nestjs/common",\
@@ -18845,13 +18732,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["typesense", [\
-      ["npm:0.14.0", {\
-        "packageLocation": "../../../.yarn/berry/cache/typesense-npm-0.14.0-016a360d01-9.zip/node_modules/typesense/",\
-        "packageDependencies": [\
-          ["typesense", "npm:0.14.0"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
       ["npm:0.15.0", {\
         "packageLocation": "../../../.yarn/berry/cache/typesense-npm-0.15.0-1d71e88629-9.zip/node_modules/typesense/",\
         "packageDependencies": [\
@@ -18859,24 +18739,10 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.14.0", {\
-        "packageLocation": "./.yarn/__virtual__/typesense-virtual-6b74f9f908/4/.yarn/berry/cache/typesense-npm-0.14.0-016a360d01-9.zip/node_modules/typesense/",\
+      ["virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0", {\
+        "packageLocation": "./.yarn/__virtual__/typesense-virtual-d325855425/4/.yarn/berry/cache/typesense-npm-0.15.0-1d71e88629-9.zip/node_modules/typesense/",\
         "packageDependencies": [\
-          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.14.0"],\
-          ["@babel/runtime", "npm:7.14.8"],\
-          ["@types/babel__runtime", null],\
-          ["axios", "npm:0.21.1"],\
-          ["loglevel", "npm:1.7.1"]\
-        ],\
-        "packagePeers": [\
-          "@types/babel__runtime"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.15.0", {\
-        "packageLocation": "./.yarn/__virtual__/typesense-virtual-1251740d93/4/.yarn/berry/cache/typesense-npm-0.15.0-1d71e88629-9.zip/node_modules/typesense/",\
-        "packageDependencies": [\
-          ["typesense", "virtual:9690aa269ed7f0963f88f2f41cdbe29b7fe04ce225fdbc61cb0a364b09b929d1c2eaed05330c6dc7cecdadc37f50c68f1353b049eb428ace77331e8d82f98f3e#npm:0.15.0"],\
+          ["typesense", "virtual:3ed64c94e7cae24ec86cfec8a414cbc264cf8f1086c8c04285262e36e99f19bb4dcd46ccc2f85b5aae6d501c2102e881b1a9ae5e9291ca11b83a33ce0e208976#npm:0.15.0"],\
           ["@babel/runtime", "npm:7.14.8"],\
           ["@types/babel__runtime", null],\
           ["axios", "npm:0.21.1"],\

--- a/packages/kratos/package.json
+++ b/packages/kratos/package.json
@@ -15,22 +15,22 @@
     "@ory/kratos-client": "0.5.5-alpha.4"
   },
   "devDependencies": {
-    "@nestjs/common": "^8.0.5",
-    "@nestjs/core": "^8.0.5",
-    "@nestjs/testing": "^8.0.5",
-    "@types/express": "^4.17.13",
-    "@types/node": "^17.0.18",
-    "express": "^4.17.3",
-    "get-port": "^5.1.1",
+    "@nestjs/common": "10.2.5",
+    "@nestjs/core": "10.2.5",
+    "@nestjs/testing": "10.2.5",
+    "@types/express": "4.17.14",
+    "@types/node": "20.6.2",
+    "express": "4.18.2",
+    "get-port": "7.0.0",
     "reflect-metadata": "0.1.13",
-    "rxjs": "7.5.4",
-    "supertest": "^6.2.2"
+    "rxjs": "7.8.1",
+    "supertest": "6.3.3"
   },
   "peerDependencies": {
-    "@nestjs/common": "^8.0.0",
-    "@nestjs/core": "^8.0.0",
-    "reflect-metadata": "^0.1.12",
-    "rxjs": "^6.3.3"
+    "@nestjs/common": "10.2.5",
+    "@nestjs/core": "10.2.5",
+    "reflect-metadata": "0.1.13",
+    "rxjs": "7.8.1"
   },
   "publishConfig": {
     "main": "dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -554,22 +554,22 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atls/nestjs-kratos@workspace:packages/kratos"
   dependencies:
-    "@nestjs/common": "npm:^8.0.5"
-    "@nestjs/core": "npm:^8.0.5"
-    "@nestjs/testing": "npm:^8.0.5"
+    "@nestjs/common": "npm:10.2.5"
+    "@nestjs/core": "npm:10.2.5"
+    "@nestjs/testing": "npm:10.2.5"
     "@ory/kratos-client": "npm:0.5.5-alpha.4"
-    "@types/express": "npm:^4.17.13"
-    "@types/node": "npm:^17.0.18"
-    express: "npm:^4.17.3"
-    get-port: "npm:^5.1.1"
+    "@types/express": "npm:4.17.14"
+    "@types/node": "npm:20.6.2"
+    express: "npm:4.18.2"
+    get-port: "npm:7.0.0"
     reflect-metadata: "npm:0.1.13"
-    rxjs: "npm:7.5.4"
-    supertest: "npm:^6.2.2"
+    rxjs: "npm:7.8.1"
+    supertest: "npm:6.3.3"
   peerDependencies:
-    "@nestjs/common": ^8.0.0
-    "@nestjs/core": ^8.0.0
-    reflect-metadata: ^0.1.12
-    rxjs: ^6.3.3
+    "@nestjs/common": 10.2.5
+    "@nestjs/core": 10.2.5
+    reflect-metadata: 0.1.13
+    rxjs: 7.8.1
   languageName: unknown
   linkType: soft
 
@@ -3805,6 +3805,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/express@npm:4.17.14":
+  version: 4.17.14
+  resolution: "@types/express@npm:4.17.14"
+  dependencies:
+    "@types/body-parser": "npm:*"
+    "@types/express-serve-static-core": "npm:^4.17.18"
+    "@types/qs": "npm:*"
+    "@types/serve-static": "npm:*"
+  checksum: 7e2d23081f1aa8d8e4218fba4e305f2a52e221a99340ecc4694482cd2878cbb344deae1b8899e7682a05cf95c9a130e97534bf0e22d983c45d25a8788351803d
+  languageName: node
+  linkType: hard
+
 "@types/express@npm:4.17.17":
   version: 4.17.17
   resolution: "@types/express@npm:4.17.17"
@@ -5434,24 +5446,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"body-parser@npm:1.19.2":
-  version: 1.19.2
-  resolution: "body-parser@npm:1.19.2"
-  dependencies:
-    bytes: "npm:3.1.2"
-    content-type: "npm:~1.0.4"
-    debug: "npm:2.6.9"
-    depd: "npm:~1.1.2"
-    http-errors: "npm:1.8.1"
-    iconv-lite: "npm:0.4.24"
-    on-finished: "npm:~2.3.0"
-    qs: "npm:6.9.7"
-    raw-body: "npm:2.4.3"
-    type-is: "npm:~1.6.18"
-  checksum: 50a4eab574306e6ed34aec8e568d5f9bcc06245b5dfa0a58dd07df633133be1d1b86da9a53bcbf528324349be0b2c180f2225aa19a5fde832cfc6836023f261d
-  languageName: node
-  linkType: hard
-
 "body-parser@npm:1.20.1":
   version: 1.20.1
   resolution: "body-parser@npm:1.20.1"
@@ -6208,13 +6202,6 @@ __metadata:
   version: 0.4.0
   resolution: "cookie@npm:0.4.0"
   checksum: 5871ebe7485411cb6c0aab5d225a675f19a96e5f569373bf22208a398d354fb455dacd101dd8000275ae04d62ef0654eba1f1944a9224ff090a78babf48cbceb
-  languageName: node
-  linkType: hard
-
-"cookie@npm:0.4.2":
-  version: 0.4.2
-  resolution: "cookie@npm:0.4.2"
-  checksum: e2b0be16f59835785be50f5dfe076c26e81ab49c988a6290144444d0dfdf8192e82b0aa1857734b292567795e7af3f2c951d82e5036a2aacb15cd4a6681b5d49
   languageName: node
   linkType: hard
 
@@ -7340,44 +7327,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express@npm:^4.17.3":
-  version: 4.17.3
-  resolution: "express@npm:4.17.3"
-  dependencies:
-    accepts: "npm:~1.3.8"
-    array-flatten: "npm:1.1.1"
-    body-parser: "npm:1.19.2"
-    content-disposition: "npm:0.5.4"
-    content-type: "npm:~1.0.4"
-    cookie: "npm:0.4.2"
-    cookie-signature: "npm:1.0.6"
-    debug: "npm:2.6.9"
-    depd: "npm:~1.1.2"
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    etag: "npm:~1.8.1"
-    finalhandler: "npm:~1.1.2"
-    fresh: "npm:0.5.2"
-    merge-descriptors: "npm:1.0.1"
-    methods: "npm:~1.1.2"
-    on-finished: "npm:~2.3.0"
-    parseurl: "npm:~1.3.3"
-    path-to-regexp: "npm:0.1.7"
-    proxy-addr: "npm:~2.0.7"
-    qs: "npm:6.9.7"
-    range-parser: "npm:~1.2.1"
-    safe-buffer: "npm:5.2.1"
-    send: "npm:0.17.2"
-    serve-static: "npm:1.14.2"
-    setprototypeof: "npm:1.2.0"
-    statuses: "npm:~1.5.0"
-    type-is: "npm:~1.6.18"
-    utils-merge: "npm:1.0.1"
-    vary: "npm:~1.1.2"
-  checksum: 50520bb89cf3da84916f21541c9437931f83663ce1dc90d7710305189ae3a09da71212fdd2cecaab3adba7f2d4cb27f64710a20c8a6f3cc3b248455faf4fc855
-  languageName: node
-  linkType: hard
-
 "extend@npm:^3.0.2, extend@npm:~3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
@@ -8468,19 +8417,6 @@ __metadata:
     statuses: "npm:>= 1.5.0 < 2"
     toidentifier: "npm:1.0.0"
   checksum: dae4b43979d5303592e4717426dc14c320887f92e6e194651847f923c7ddfb98ba1b33d8071dde859d9d63730d1f94aebd9838ab044e817a1d1b97792dd9d36d
-  languageName: node
-  linkType: hard
-
-"http-errors@npm:1.8.1":
-  version: 1.8.1
-  resolution: "http-errors@npm:1.8.1"
-  dependencies:
-    depd: "npm:~1.1.2"
-    inherits: "npm:2.0.4"
-    setprototypeof: "npm:1.2.0"
-    statuses: "npm:>= 1.5.0 < 2"
-    toidentifier: "npm:1.0.1"
-  checksum: 35821fd7ea2f567ab92dfa75dee08771cfe9399ce2c458e46f75915d0e13a087f224e326ab3bab78d2d8e930cf0f6e2280727cb28ed5b500a435a8c5e74e4f76
   languageName: node
   linkType: hard
 
@@ -11581,13 +11517,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:6.9.7":
-  version: 6.9.7
-  resolution: "qs@npm:6.9.7"
-  checksum: 93f75cd622be38fc3da0e7d922ffdd93e4e7a5a7fad009f8007c13e76e1d5ce996e33e3d090b34598084241850534dfd29700577be91e459b9d6cca20887d1c1
-  languageName: node
-  linkType: hard
-
 "qs@npm:^6.10.1":
   version: 6.10.3
   resolution: "qs@npm:6.10.3"
@@ -11643,18 +11572,6 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: f7c9d860b823496bb66ec8765a0b2f90928c1970e6e11992bdfa20481dea704617e7200c8cfb761341be0f45a552ea3e63a5c5ff601041f50311f2b3109fd513
-  languageName: node
-  linkType: hard
-
-"raw-body@npm:2.4.3":
-  version: 2.4.3
-  resolution: "raw-body@npm:2.4.3"
-  dependencies:
-    bytes: "npm:3.1.2"
-    http-errors: "npm:1.8.1"
-    iconv-lite: "npm:0.4.24"
-    unpipe: "npm:1.0.0"
-  checksum: 9225e243251363b02d05664b1459db478e48c8929f0743afb04aaab59091b7ca0c1bd28a20b82edeb7011d757b2e78b3593d29841573e525c020d0f7696b0907
   languageName: node
   linkType: hard
 
@@ -12091,27 +12008,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"send@npm:0.17.2":
-  version: 0.17.2
-  resolution: "send@npm:0.17.2"
-  dependencies:
-    debug: "npm:2.6.9"
-    depd: "npm:~1.1.2"
-    destroy: "npm:~1.0.4"
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    etag: "npm:~1.8.1"
-    fresh: "npm:0.5.2"
-    http-errors: "npm:1.8.1"
-    mime: "npm:1.6.0"
-    ms: "npm:2.1.3"
-    on-finished: "npm:~2.3.0"
-    range-parser: "npm:~1.2.1"
-    statuses: "npm:~1.5.0"
-  checksum: d74a7537d824c3d801e25bf759418e4d4759f40017f5c22ae2557e68771b661a8c6af3194ac759f8386b7c07a5d6938b6051f081462d3c0126dabfae57131953
-  languageName: node
-  linkType: hard
-
 "send@npm:0.18.0":
   version: 0.18.0
   resolution: "send@npm:0.18.0"
@@ -12153,18 +12049,6 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.17.1"
   checksum: a8a7ccfaf30332279198bc7f7b0b65c5528d3837c9262f54012641bf9617acc9ebf2ee5b694dba790013853da714090d8adb1d97269e0d5acad077ffab01ed55
-  languageName: node
-  linkType: hard
-
-"serve-static@npm:1.14.2":
-  version: 1.14.2
-  resolution: "serve-static@npm:1.14.2"
-  dependencies:
-    encodeurl: "npm:~1.0.2"
-    escape-html: "npm:~1.0.3"
-    parseurl: "npm:~1.3.3"
-    send: "npm:0.17.2"
-  checksum: 67532ae072f1b47d2b22939fd3ee4f82a962d6976f31baff261d7b72171f8457d908ff3a011a48e77cb570ee986fee145dc33786b8579ce7db381362aa68bdff
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4030,7 +4030,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:17.0.18, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:^17.0.12, @types/node@npm:^17.0.18":
+"@types/node@npm:*, @types/node@npm:17.0.18, @types/node@npm:>=12.12.47, @types/node@npm:>=13.7.0, @types/node@npm:^17.0.12":
   version: 17.0.18
   resolution: "@types/node@npm:17.0.18"
   checksum: 181ee79dfec9184c9d2d5071696651412d5a8cc524a0fdc4ec867fa97ae4f874dae6f9c0dc76157525c9156d80d1ef5f980327e23a34e199baba0348cdffc62f


### PR DESCRIPTION
**All dependencies updated to the last versions in the `kratos` module**

**Except:**

`@ory/kratos-client` - moved from the alpha version to the release, needs to update all api in the `kratos` module

~`get-port` - updated to 6.1.2, the maximum available version: 7.0.0, an error occurs when trying to update to 7.0.0~ fixed

`@types/express` - updated to 4.17.13, the maximum available version: 4.17.17: when trying to use it, there is a conflict with `@types/express-serve-static-core`, failed to raise the version above 4.17.13, [issue about this](https://github.com/DefinitelyTyped/DefinitelyTyped/issues/53397)
