### PR TITLE
Update logger dependencies versions

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -1125,15 +1125,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "./packages/logger/",\
         "packageDependencies": [\
           ["@atls/nestjs-logger", "workspace:packages/logger"],\
-          ["@atls/logger", "npm:0.0.1"],\
-          ["@nestjs/common", "virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#npm:8.0.5"],\
-          ["@nestjs/core", "virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5"],\
-          ["@nestjs/testing", "virtual:ce6e270dd1a913383e665adba70cc98d266ccaf9b82d6842ca76d9a267595f17392335d4f77efe1fba88c49b9f83113b77096a14512ffbac711a190b6046caa1#npm:8.0.5"],\
-          ["@types/node", "npm:17.0.18"],\
-          ["get-port", "npm:5.1.1"],\
+          ["@atls/logger", "npm:0.0.2"],\
+          ["@nestjs/common", "virtual:03b6af22cb80149b513f081c991b2ee015111d59bbeac45ddf1903895b7fd87d34f48a2f3c80a4ef3aface38a0df360e482b938a22fb0c3db73366f989167c03#npm:10.2.5"],\
+          ["@nestjs/core", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@nestjs/testing", "virtual:3da99a4dd1a45fbb12f3936831275fe6ef127b2869363613ce7e5fc10bfba69fce118823d76d677d80a9d976776b1a4cb7b1bb4ee5c5a306e3ceed973bf055a2#npm:10.2.5"],\
+          ["@types/node", "npm:20.6.2"],\
+          ["get-port", "npm:7.0.0"],\
           ["reflect-metadata", "npm:0.1.13"],\
-          ["rxjs", "npm:7.5.4"],\
-          ["supertest", "npm:6.2.2"],\
+          ["rxjs", "npm:7.8.1"],\
+          ["supertest", "npm:6.3.3"],\
           ["typeorm", "virtual:2be7684f2ba6382db35d73aed842104189f9b09e1687c98a05e572834f9a945a2a972003e8bb0d7615b796a2608474f1b5fb5865d711f44884baeb7e2ffd9e61#npm:0.2.45"]\
         ],\
         "linkType": "SOFT"\
@@ -7734,6 +7734,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../../../.yarn/berry/cache/@types-node-npm-20.6.0-73d5022935-9.zip/node_modules/@types/node/",\
         "packageDependencies": [\
           ["@types/node", "npm:20.6.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:20.6.2", {\
+        "packageLocation": "../../../.yarn/berry/cache/@types-node-npm-20.6.2-bff5d8378f-9.zip/node_modules/@types/node/",\
+        "packageDependencies": [\
+          ["@types/node", "npm:20.6.2"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -26,7 +26,7 @@
     "reflect-metadata": "0.1.13",
     "rxjs": "7.8.1",
     "supertest": "6.3.3",
-    "typeorm": "*"
+    "typeorm": "0.2.45"
   },
   "peerDependencies": {
     "@nestjs/common": "10.2.5",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -15,24 +15,24 @@
     "postpack": "rm -rf dist"
   },
   "dependencies": {
-    "@atls/logger": "^0.0.1"
+    "@atls/logger": "0.0.2"
   },
   "devDependencies": {
-    "@nestjs/common": "^8.0.5",
-    "@nestjs/core": "^8.0.5",
-    "@nestjs/testing": "^8.0.5",
-    "@types/node": "^17.0.18",
-    "get-port": "^5.1.1",
+    "@nestjs/common": "10.2.5",
+    "@nestjs/core": "10.2.5",
+    "@nestjs/testing": "10.2.5",
+    "@types/node": "20.6.2",
+    "get-port": "7.0.0",
     "reflect-metadata": "0.1.13",
-    "rxjs": "7.5.4",
-    "supertest": "^6.2.2",
+    "rxjs": "7.8.1",
+    "supertest": "6.3.3",
     "typeorm": "*"
   },
   "peerDependencies": {
-    "@nestjs/common": "^8.0.0",
-    "@nestjs/core": "^8.0.0",
-    "reflect-metadata": "^0.1.12",
-    "rxjs": "^6.3.3"
+    "@nestjs/common": "10.2.5",
+    "@nestjs/core": "10.2.5",
+    "reflect-metadata": "0.1.13",
+    "rxjs": "7.8.1"
   },
   "publishConfig": {
     "main": "dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,7 +586,7 @@ __metadata:
     reflect-metadata: "npm:0.1.13"
     rxjs: "npm:7.8.1"
     supertest: "npm:6.3.3"
-    typeorm: "npm:*"
+    typeorm: "npm:0.2.45"
   peerDependencies:
     "@nestjs/common": 10.2.5
     "@nestjs/core": 10.2.5

--- a/yarn.lock
+++ b/yarn.lock
@@ -577,21 +577,21 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atls/nestjs-logger@workspace:packages/logger"
   dependencies:
-    "@atls/logger": "npm:^0.0.1"
-    "@nestjs/common": "npm:^8.0.5"
-    "@nestjs/core": "npm:^8.0.5"
-    "@nestjs/testing": "npm:^8.0.5"
-    "@types/node": "npm:^17.0.18"
-    get-port: "npm:^5.1.1"
+    "@atls/logger": "npm:0.0.2"
+    "@nestjs/common": "npm:10.2.5"
+    "@nestjs/core": "npm:10.2.5"
+    "@nestjs/testing": "npm:10.2.5"
+    "@types/node": "npm:20.6.2"
+    get-port: "npm:7.0.0"
     reflect-metadata: "npm:0.1.13"
-    rxjs: "npm:7.5.4"
-    supertest: "npm:^6.2.2"
+    rxjs: "npm:7.8.1"
+    supertest: "npm:6.3.3"
     typeorm: "npm:*"
   peerDependencies:
-    "@nestjs/common": ^8.0.0
-    "@nestjs/core": ^8.0.0
-    reflect-metadata: ^0.1.12
-    rxjs: ^6.3.3
+    "@nestjs/common": 10.2.5
+    "@nestjs/core": 10.2.5
+    reflect-metadata: 0.1.13
+    rxjs: 7.8.1
   languageName: unknown
   linkType: soft
 
@@ -4036,6 +4036,13 @@ __metadata:
   version: 20.6.0
   resolution: "@types/node@npm:20.6.0"
   checksum: a47628ac5cc1306bdc1892f9499b4f446b7859390514a38f2108f7703854591fa4e7339cf8af910598fe26024d87dce9951f0371b41c057f9c67c63e119d8f0b
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:20.6.2":
+  version: 20.6.2
+  resolution: "@types/node@npm:20.6.2"
+  checksum: 3e0ef85112a2d7348382c3c5ab5211634e3413a496c112be2f11b07f31a4cd26417f365ddc8589f7268fbcba44a630bc7249b5364088d75c6d5ed1a93bfdb7e6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
All dependencies updated to the last versions in the `logger` module

Skipped:
`typeorm` - by definition of issue