### PR TITLE
chore(nestjs-cqrs-kafka-events): trigger npm publish

### DIFF
--- a/packages/nestjs-cqrs-kafka-events/src/index.ts
+++ b/packages/nestjs-cqrs-kafka-events/src/index.ts
@@ -1,4 +1,4 @@
-export * from '@atls/nestjs-kafka'
-
 export * from './messaging/index.js'
 export * from './module/index.js'
+
+export * from '@atls/nestjs-kafka'


### PR DESCRIPTION
Предыдущий [publish](https://github.com/atls/nestjs/actions/runs/13863128272/job/38796138179#step:13:1) не прошел