### PR TITLE
chore(github): format repository templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ops.yaml
+++ b/.github/ISSUE_TEMPLATE/ops.yaml
@@ -1,6 +1,6 @@
 name: OPS
 description: Operations Tasks
-title: "[OPS] "
+title: '[OPS] '
 type: OPS
 assignees:
   - TorinAsakura

--- a/.github/ISSUE_TEMPLATE/product.yaml
+++ b/.github/ISSUE_TEMPLATE/product.yaml
@@ -9,7 +9,7 @@ body:
     id: motivation
     attributes:
       label: What are we doing?
-      description: "For example: chatbot, admin panel, API"
+      description: 'For example: chatbot, admin panel, API'
     validations:
       required: true
 
@@ -17,7 +17,7 @@ body:
     id: scope
     attributes:
       label: What is included in the task scope?
-      description: "List the main features"
+      description: 'List the main features'
     validations:
       required: true
 
@@ -25,7 +25,7 @@ body:
     id: requirements
     attributes:
       label: Requirements
-      description: "List the requirements the final result must satisfy"
+      description: 'List the requirements the final result must satisfy'
     validations:
       required: true
 
@@ -33,6 +33,6 @@ body:
     id: results
     attributes:
       label: Expected result
-      description: "Briefly list what exactly will be delivered: artifacts, data, functionality"
+      description: 'Briefly list what exactly will be delivered: artifacts, data, functionality'
     validations:
       required: false

--- a/.github/PULL_REQUEST_TEMPLATE/bugfix.md
+++ b/.github/PULL_REQUEST_TEMPLATE/bugfix.md
@@ -1,24 +1,33 @@
 ## Task
+
 - Close owner/repo#N
 
 ## How to verify
+
 ### Before the fix
+
 1. Context: ... (frontend screen / backend endpoint / job / infra command)
-Action: ...
-Expected result: ...
+   Action: ...
+   Expected result: ...
 
 ### After the fix
+
 1. Context: ... (frontend screen / backend endpoint / job / infra command)
-Action: ...
-Expected result: ...
+   Action: ...
+   Expected result: ...
 
 ## Proofs
+
 - `endpoint name` raw request
+
 ```json
 {}
 ```
+
 - `endpoint name` raw response
+
 ```json
 {}
 ```
+
 - for frontend: screenshot or screencast in `<details>`

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,24 +1,33 @@
 ## Task
+
 - Close owner/repo#N
 
 ## How to verify
+
 ### Main scenario
+
 1. Context: ... (frontend screen / backend endpoint / job / infra command)
-Action: ...
-Expected result: ...
+   Action: ...
+   Expected result: ...
 
 ### Additional scenario
+
 1. Context: ... (frontend screen / backend endpoint / job / infra command)
-Action: ...
-Expected result: ...
+   Action: ...
+   Expected result: ...
 
 ## Proofs
+
 - `endpoint name` raw request
+
 ```json
 {}
 ```
+
 - `endpoint name` raw response
+
 ```json
 {}
 ```
+
 - for frontend: screenshot or screencast in `<details>`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,24 +1,32 @@
 > Profile templates:
+>
 > - bugfix: `.github/PULL_REQUEST_TEMPLATE/bugfix.md`
 > - feature: `.github/PULL_REQUEST_TEMPLATE/feature.md`
 >
 > If no profile is selected, use this general template
 
 ## Task
+
 - Close owner/repo#N
 
 ## How to verify
+
 1. Context: ... (frontend screen / backend endpoint / job / infra command)
-Action: ...
-Expected result: ...
+   Action: ...
+   Expected result: ...
 
 ## Proofs
+
 - `endpoint name` raw request
+
 ```json
 {}
 ```
+
 - `endpoint name` raw response
+
 ```json
 {}
 ```
+
 - for frontend: screenshot or screencast in `<details>`


### PR DESCRIPTION
## Task

- Extract formatter-only GitHub issue and PR template changes from atls/nestjs#392

## How to verify

1. Context: GitHub repository templates
   Action: inspect the changed files
   Expected result: only issue and PR template formatting changed

## Proofs

- `git diff --check HEAD~1..HEAD`

```text
passed
```

- changed files

```text
.github/ISSUE_TEMPLATE/ops.yaml
.github/ISSUE_TEMPLATE/product.yaml
.github/PULL_REQUEST_TEMPLATE/bugfix.md
.github/PULL_REQUEST_TEMPLATE/feature.md
.github/pull_request_template.md
```
