### PR TITLE
feat(nestjs-signed-url): wire gcs client boundary

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -172,7 +172,7 @@ const RAW_RUNTIME_STATE =
     ["@atls/nestjs-dataloader", ["workspace:packages/nestjs-dataloader"]],\
     ["@atls/nestjs-external-renderer", ["workspace:packages/nestjs-external-renderer"]],\
     ["@atls/nestjs-gateway", ["workspace:packages/nestjs-gateway"]],\
-    ["@atls/nestjs-gcs-client", ["workspace:packages/nestjs-gcs-client"]],\
+    ["@atls/nestjs-gcs-client", ["virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#workspace:packages/nestjs-gcs-client", "workspace:packages/nestjs-gcs-client"]],\
     ["@atls/nestjs-graphql-redis-subscriptions", ["workspace:packages/nestjs-graphql-redis-subscriptions"]],\
     ["@atls/nestjs-grpc-errors", ["workspace:packages/nestjs-grpc-errors"]],\
     ["@atls/nestjs-grpc-http-proxy", ["virtual:77887786a24289fa840c9acd370d634accbe79bcf317ecf5401844ffff73b8a593879dd9cce463873637e6414a631dfdb1a2473704bf332d823bcfffac8c2469#workspace:packages/nestjs-grpc-http-proxy", "virtual:80857f29dff653ed1b21e1b78c415c79278e1a3708fec8563133922c0b3b287990dd6895d3d76575acec38e5f7e5fa8985f270e2d46a7eb121f744d431d0761f#workspace:packages/nestjs-grpc-http-proxy", "virtual:ae612755b7b7524f0abe0e8f8a9db7ce3c40babcf859fc76be80f623f21186ae03161e438d67e313be3df3064d77d055596efe3c17a2ac659a9ce043f3f557d0#workspace:packages/nestjs-grpc-http-proxy", "workspace:packages/nestjs-grpc-http-proxy"]],\
@@ -809,11 +809,37 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@atls/nestjs-gcs-client", [\
+      ["virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#workspace:packages/nestjs-gcs-client", {\
+        "packageLocation": "./.yarn/__virtual__/@atls-nestjs-gcs-client-virtual-605e93554f/1/packages/nestjs-gcs-client/",\
+        "packageDependencies": [\
+          ["@atls/nestjs-gcs-client", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#workspace:packages/nestjs-gcs-client"],\
+          ["@google-cloud/storage", "npm:7.13.0"],\
+          ["@nestjs/common", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:10.4.4"],\
+          ["@nestjs/core", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:10.4.4"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["reflect-metadata", "npm:0.2.2"],\
+          ["rxjs", "npm:7.8.1"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "SOFT"\
+      }],\
       ["workspace:packages/nestjs-gcs-client", {\
         "packageLocation": "./packages/nestjs-gcs-client/",\
         "packageDependencies": [\
           ["@atls/nestjs-gcs-client", "workspace:packages/nestjs-gcs-client"],\
-          ["@google-cloud/storage", "npm:7.0.1"],\
+          ["@google-cloud/storage", "npm:7.13.0"],\
           ["@nestjs/common", "virtual:773e124e6d7d5c23e2706ffde057b7c1d13d30452fb17121aed2189489091a233a955fdd9b958f8fa713a6cdbe245c696fcd7e05eb8d3e4a938f0a00ad757325#npm:10.4.15"],\
           ["@nestjs/core", "virtual:773e124e6d7d5c23e2706ffde057b7c1d13d30452fb17121aed2189489091a233a955fdd9b958f8fa713a6cdbe245c696fcd7e05eb8d3e4a938f0a00ad757325#npm:10.4.15"],\
           ["reflect-metadata", "npm:0.2.2"],\
@@ -1598,6 +1624,7 @@ const RAW_RUNTIME_STATE =
       ["workspace:packages/nestjs-signed-url", {\
         "packageLocation": "./packages/nestjs-signed-url/",\
         "packageDependencies": [\
+          ["@atls/nestjs-gcs-client", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#workspace:packages/nestjs-gcs-client"],\
           ["@atls/nestjs-signed-url", "workspace:packages/nestjs-signed-url"],\
           ["@google-cloud/storage", "npm:7.13.0"],\
           ["@jest/globals", "npm:29.7.0"],\
@@ -4179,15 +4206,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@google-cloud/paginator", [\
-      ["npm:3.0.7", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-paginator-npm-3.0.7-b5e7c7f423-10c0.zip/node_modules/@google-cloud/paginator/",\
-        "packageDependencies": [\
-          ["@google-cloud/paginator", "npm:3.0.7"],\
-          ["arrify", "npm:2.0.1"],\
-          ["extend", "npm:3.0.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:5.0.2", {\
         "packageLocation": "../.yarn/berry/cache/@google-cloud-paginator-npm-5.0.2-7d2d8fc828-10c0.zip/node_modules/@google-cloud/paginator/",\
         "packageDependencies": [\
@@ -4199,13 +4217,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@google-cloud/projectify", [\
-      ["npm:3.0.0", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-projectify-npm-3.0.0-ba9df71402-10c0.zip/node_modules/@google-cloud/projectify/",\
-        "packageDependencies": [\
-          ["@google-cloud/projectify", "npm:3.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:4.0.0", {\
         "packageLocation": "../.yarn/berry/cache/@google-cloud-projectify-npm-4.0.0-013ddf774f-10c0.zip/node_modules/@google-cloud/projectify/",\
         "packageDependencies": [\
@@ -4215,13 +4226,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@google-cloud/promisify", [\
-      ["npm:3.0.1", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-promisify-npm-3.0.1-17dfc5a8e5-10c0.zip/node_modules/@google-cloud/promisify/",\
-        "packageDependencies": [\
-          ["@google-cloud/promisify", "npm:3.0.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:4.0.0", {\
         "packageLocation": "../.yarn/berry/cache/@google-cloud-promisify-npm-4.0.0-abe4f29539-10c0.zip/node_modules/@google-cloud/promisify/",\
         "packageDependencies": [\
@@ -4231,30 +4235,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@google-cloud/storage", [\
-      ["npm:7.0.1", {\
-        "packageLocation": "../.yarn/berry/cache/@google-cloud-storage-npm-7.0.1-c18729b1ec-10c0.zip/node_modules/@google-cloud/storage/",\
-        "packageDependencies": [\
-          ["@google-cloud/paginator", "npm:3.0.7"],\
-          ["@google-cloud/projectify", "npm:3.0.0"],\
-          ["@google-cloud/promisify", "npm:3.0.1"],\
-          ["@google-cloud/storage", "npm:7.0.1"],\
-          ["abort-controller", "npm:3.0.0"],\
-          ["async-retry", "npm:1.3.3"],\
-          ["compressible", "npm:2.0.18"],\
-          ["duplexify", "npm:4.1.3"],\
-          ["ent", "npm:2.2.2"],\
-          ["fast-xml-parser", "npm:4.5.3"],\
-          ["gaxios", "npm:6.7.1"],\
-          ["google-auth-library", "npm:9.15.1"],\
-          ["mime", "npm:3.0.0"],\
-          ["mime-types", "npm:2.1.35"],\
-          ["p-limit", "npm:3.1.0"],\
-          ["retry-request", "npm:6.0.0"],\
-          ["teeny-request", "npm:9.0.0"],\
-          ["uuid", "npm:8.3.2"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:7.13.0", {\
         "packageLocation": "../.yarn/berry/cache/@google-cloud-storage-npm-7.13.0-afdd7e7013-10c0.zip/node_modules/@google-cloud/storage/",\
         "packageDependencies": [\
@@ -15166,16 +15146,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["compressible", [\
-      ["npm:2.0.18", {\
-        "packageLocation": "../.yarn/berry/cache/compressible-npm-2.0.18-ee5ab04d88-10c0.zip/node_modules/compressible/",\
-        "packageDependencies": [\
-          ["compressible", "npm:2.0.18"],\
-          ["mime-db", "npm:1.53.0"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["concat-map", [\
       ["npm:0.0.1", {\
         "packageLocation": "../.yarn/berry/cache/concat-map-npm-0.0.1-85a921b7ee-10c0.zip/node_modules/concat-map/",\
@@ -16119,19 +16089,6 @@ const RAW_RUNTIME_STATE =
           ["enhanced-resolve", "npm:5.18.0"],\
           ["graceful-fs", "npm:4.2.11"],\
           ["tapable", "npm:2.2.1"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
-    ["ent", [\
-      ["npm:2.2.2", {\
-        "packageLocation": "../.yarn/berry/cache/ent-npm-2.2.2-3dff4b3220-10c0.zip/node_modules/ent/",\
-        "packageDependencies": [\
-          ["call-bound", "npm:1.0.3"],\
-          ["ent", "npm:2.2.2"],\
-          ["es-errors", "npm:1.3.0"],\
-          ["punycode", "npm:1.4.1"],\
-          ["safe-regex-test", "npm:1.1.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17442,14 +17399,6 @@ const RAW_RUNTIME_STATE =
           ["strnum", "npm:1.0.5"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:4.5.3", {\
-        "packageLocation": "../.yarn/berry/cache/fast-xml-parser-npm-4.5.3-4c572a6316-10c0.zip/node_modules/fast-xml-parser/",\
-        "packageDependencies": [\
-          ["fast-xml-parser", "npm:4.5.3"],\
-          ["strnum", "npm:1.1.2"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["fastq", [\
@@ -18225,19 +18174,6 @@ const RAW_RUNTIME_STATE =
           ["gaxios", "npm:6.7.1"],\
           ["gcp-metadata", "npm:6.1.0"],\
           ["google-auth-library", "npm:9.14.2"],\
-          ["gtoken", "npm:7.1.0"],\
-          ["jws", "npm:4.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:9.15.1", {\
-        "packageLocation": "../.yarn/berry/cache/google-auth-library-npm-9.15.1-04a025e628-10c0.zip/node_modules/google-auth-library/",\
-        "packageDependencies": [\
-          ["base64-js", "npm:1.5.1"],\
-          ["ecdsa-sig-formatter", "npm:1.0.11"],\
-          ["gaxios", "npm:6.7.1"],\
-          ["gcp-metadata", "npm:6.1.0"],\
-          ["google-auth-library", "npm:9.15.1"],\
           ["gtoken", "npm:7.1.0"],\
           ["jws", "npm:4.0.0"]\
         ],\
@@ -20587,13 +20523,6 @@ const RAW_RUNTIME_STATE =
           ["mime-db", "npm:1.52.0"]\
         ],\
         "linkType": "HARD"\
-      }],\
-      ["npm:1.53.0", {\
-        "packageLocation": "../.yarn/berry/cache/mime-db-npm-1.53.0-14fcdba2be-10c0.zip/node_modules/mime-db/",\
-        "packageDependencies": [\
-          ["mime-db", "npm:1.53.0"]\
-        ],\
-        "linkType": "HARD"\
       }]\
     ]],\
     ["mime-types", [\
@@ -21845,13 +21774,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["punycode", [\
-      ["npm:1.4.1", {\
-        "packageLocation": "../.yarn/berry/cache/punycode-npm-1.4.1-be4c23e6d2-10c0.zip/node_modules/punycode/",\
-        "packageDependencies": [\
-          ["punycode", "npm:1.4.1"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:2.3.1", {\
         "packageLocation": "../.yarn/berry/cache/punycode-npm-2.3.1-97543c420d-10c0.zip/node_modules/punycode/",\
         "packageDependencies": [\
@@ -22329,15 +22251,6 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["retry-request", [\
-      ["npm:6.0.0", {\
-        "packageLocation": "../.yarn/berry/cache/retry-request-npm-6.0.0-588a2f977d-10c0.zip/node_modules/retry-request/",\
-        "packageDependencies": [\
-          ["debug", "virtual:1b9e2a314c35921e1b14ca2d2c7664f165a5c0f3f02ca1e30357c6546941724b55e5624ce0d5b4790874f2259ae08ae26d9f95d2cdbb84aae50aa451a2a572cd#npm:4.3.7"],\
-          ["extend", "npm:3.0.2"],\
-          ["retry-request", "npm:6.0.0"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["npm:7.0.2", {\
         "packageLocation": "../.yarn/berry/cache/retry-request-npm-7.0.2-a41087680c-10c0.zip/node_modules/retry-request/",\
         "packageDependencies": [\
@@ -23267,13 +23180,6 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/strnum-npm-1.0.5-9ba11d2a0a-10c0.zip/node_modules/strnum/",\
         "packageDependencies": [\
           ["strnum", "npm:1.0.5"]\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["npm:1.1.2", {\
-        "packageLocation": "../.yarn/berry/cache/strnum-npm-1.1.2-67427480d6-10c0.zip/node_modules/strnum/",\
-        "packageDependencies": [\
-          ["strnum", "npm:1.1.2"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/packages/nestjs-gcs-client/package.json
+++ b/packages/nestjs-gcs-client/package.json
@@ -17,7 +17,7 @@
     "postpack": "rm -rf dist"
   },
   "dependencies": {
-    "@google-cloud/storage": "7.0.1"
+    "@google-cloud/storage": "7.13.0"
   },
   "devDependencies": {
     "@nestjs/common": "10.4.15",

--- a/packages/nestjs-signed-url/gcs/tests/module.test.ts
+++ b/packages/nestjs-signed-url/gcs/tests/module.test.ts
@@ -12,6 +12,9 @@ import { it }                            from 'node:test'
 import { Inject }                        from '@nestjs/common'
 import { Test }                          from '@nestjs/testing'
 
+import { GcsClientFactory }              from '@atls/nestjs-gcs-client'
+import { GcsClientModule }               from '@atls/nestjs-gcs-client'
+
 import { SIGNED_URL_GATEWAY }            from '../../src/constants.js'
 import { GCS_SIGNED_URL_CLIENT }         from '../../src/gcs/index.js'
 import { GcsSignedUrlSigner }            from '../../src/gcs/signer.js'
@@ -115,6 +118,56 @@ describe('SignedUrlModule', () => {
       virtualHostedStyle: true,
       action: 'read',
       expires: 1730000000000,
+    })
+  })
+
+  it('wires the public gcs-client module boundary into the signed-url signer', async () => {
+    const { client, storage } = createFakeGcsStorage('gcs-client-boundary-signed-url')
+    const gcsClientFactory: Pick<GcsClientFactory, 'create'> = {
+      create: (): Storage => storage,
+    }
+
+    moduleRef = await Test.createTestingModule({
+      imports: [
+        SignedUrlModule.gcsAsync<[GcsClientFactory]>({
+          imports: [GcsClientModule.register()],
+          inject: [GcsClientFactory],
+          useFactory: (factory: GcsClientFactory): Storage => factory.create(),
+        }),
+      ],
+      providers: [TestingGcsClientConsumer],
+    })
+      .overrideProvider(GcsClientFactory)
+      .useValue(gcsClientFactory)
+      .compile()
+
+    const signer = moduleRef.get(GcsSignedUrlSigner)
+    const consumer = moduleRef.get(TestingGcsClientConsumer)
+
+    assert.equal(consumer.storage, storage)
+
+    const value = await signer.generateWriteUrl('bucket', 'file.png', {
+      contentType: 'image/png',
+      expiresAt: 1730000000000,
+      headers: {
+        'x-goog-meta-origin': 'gcs-client-boundary',
+      },
+      responseDisposition: 'inline',
+    })
+
+    assert.deepEqual(value, {
+      url: 'gcs-client-boundary-signed-url',
+      fields: [],
+    })
+    assert.deepEqual(client.fileObject.params, {
+      version: 'v4',
+      action: 'write',
+      expires: 1730000000000,
+      extensionHeaders: {
+        'x-goog-meta-origin': 'gcs-client-boundary',
+      },
+      responseDisposition: 'inline',
+      contentType: 'image/png',
     })
   })
 })

--- a/packages/nestjs-signed-url/package.json
+++ b/packages/nestjs-signed-url/package.json
@@ -18,6 +18,7 @@
     "postpack": "rm -rf dist"
   },
   "devDependencies": {
+    "@atls/nestjs-gcs-client": "workspace:*",
     "@google-cloud/storage": "7.13.0",
     "@jest/globals": "29.7.0",
     "@nestjs/common": "10.4.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -542,11 +542,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@atls/nestjs-gcs-client@workspace:packages/nestjs-gcs-client":
+"@atls/nestjs-gcs-client@workspace:*, @atls/nestjs-gcs-client@workspace:packages/nestjs-gcs-client":
   version: 0.0.0-use.local
   resolution: "@atls/nestjs-gcs-client@workspace:packages/nestjs-gcs-client"
   dependencies:
-    "@google-cloud/storage": "npm:7.0.1"
+    "@google-cloud/storage": "npm:7.13.0"
     "@nestjs/common": "npm:10.4.15"
     "@nestjs/core": "npm:10.4.15"
     reflect-metadata: "npm:0.2.2"
@@ -978,6 +978,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@atls/nestjs-signed-url@workspace:packages/nestjs-signed-url"
   dependencies:
+    "@atls/nestjs-gcs-client": "workspace:*"
     "@google-cloud/storage": "npm:7.13.0"
     "@jest/globals": "npm:29.7.0"
     "@nestjs/common": "npm:10.4.4"
@@ -2963,16 +2964,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/paginator@npm:^3.0.7":
-  version: 3.0.7
-  resolution: "@google-cloud/paginator@npm:3.0.7"
-  dependencies:
-    arrify: "npm:^2.0.0"
-    extend: "npm:^3.0.2"
-  checksum: 10c0/589f08435591897f694f18c154cd36a69c7094da40668b713152faefbba9fe0a46a85eb46d9f0160c698f21b61a86b11dfc21cd74b1c071b96b45e8892e41184
-  languageName: node
-  linkType: hard
-
 "@google-cloud/paginator@npm:^5.0.0":
   version: 5.0.2
   resolution: "@google-cloud/paginator@npm:5.0.2"
@@ -2983,13 +2974,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/projectify@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "@google-cloud/projectify@npm:3.0.0"
-  checksum: 10c0/b7309cb8c7565c0fe735f69520e9531f5212a5136fc26b00b9b34cbe9a7dfc4a7c7f9efff9e299dd7dced666865063acc47d22294da4ba79fcfd93429c239d8a
-  languageName: node
-  linkType: hard
-
 "@google-cloud/projectify@npm:^4.0.0":
   version: 4.0.0
   resolution: "@google-cloud/projectify@npm:4.0.0"
@@ -2997,42 +2981,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@google-cloud/promisify@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "@google-cloud/promisify@npm:3.0.1"
-  checksum: 10c0/b37a7e5797b0cd23d9cc0f171e6e97879d62be7359467a83155339b472eaaed8ffce657cc206a79ca1e6aad66b68718649e7915d9ea52fc61d8fc21589db27f3
-  languageName: node
-  linkType: hard
-
 "@google-cloud/promisify@npm:^4.0.0":
   version: 4.0.0
   resolution: "@google-cloud/promisify@npm:4.0.0"
   checksum: 10c0/4332cbd923d7c6943ecdf46f187f1417c84bb9c801525cd74d719c766bfaad650f7964fb74576345f6537b6d6273a4f2992c8d79ebec6c8b8401b23d626b8dd3
-  languageName: node
-  linkType: hard
-
-"@google-cloud/storage@npm:7.0.1":
-  version: 7.0.1
-  resolution: "@google-cloud/storage@npm:7.0.1"
-  dependencies:
-    "@google-cloud/paginator": "npm:^3.0.7"
-    "@google-cloud/projectify": "npm:^3.0.0"
-    "@google-cloud/promisify": "npm:^3.0.0"
-    abort-controller: "npm:^3.0.0"
-    async-retry: "npm:^1.3.3"
-    compressible: "npm:^2.0.12"
-    duplexify: "npm:^4.0.0"
-    ent: "npm:^2.2.0"
-    fast-xml-parser: "npm:^4.2.2"
-    gaxios: "npm:^6.0.2"
-    google-auth-library: "npm:^9.0.0"
-    mime: "npm:^3.0.0"
-    mime-types: "npm:^2.0.8"
-    p-limit: "npm:^3.0.1"
-    retry-request: "npm:^6.0.0"
-    teeny-request: "npm:^9.0.0"
-    uuid: "npm:^8.0.0"
-  checksum: 10c0/c2190f4aacefbdcfd0f9df78a4d4a868a4218dda8aae4db402842141c202e7cbc38a9e0fe85f3908db94548a458fa4cc29770e070fcc948d630e7e750a54dbe9
   languageName: node
   linkType: hard
 
@@ -9535,15 +9487,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compressible@npm:^2.0.12":
-  version: 2.0.18
-  resolution: "compressible@npm:2.0.18"
-  dependencies:
-    mime-db: "npm:>= 1.43.0 < 2"
-  checksum: 10c0/8a03712bc9f5b9fe530cc5a79e164e665550d5171a64575d7dcf3e0395d7b4afa2d79ab176c61b5b596e28228b350dd07c1a2a6ead12fd81d1b6cd632af2fef7
-  languageName: node
-  linkType: hard
-
 "concat-map@npm:0.0.1":
   version: 0.0.1
   resolution: "concat-map@npm:0.0.1"
@@ -10234,7 +10177,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"duplexify@npm:^4.0.0, duplexify@npm:^4.1.3":
+"duplexify@npm:^4.1.3":
   version: 4.1.3
   resolution: "duplexify@npm:4.1.3"
   dependencies:
@@ -10353,18 +10296,6 @@ __metadata:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
   checksum: 10c0/5fcc264a6040754ab5b349628cac2bb5f89cee475cbe340804e657a5b9565f70e6aafb338d5895554eb0ced9f66c50f38a255274a0591dcb64ee17c549c459ce
-  languageName: node
-  linkType: hard
-
-"ent@npm:^2.2.0":
-  version: 2.2.2
-  resolution: "ent@npm:2.2.2"
-  dependencies:
-    call-bound: "npm:^1.0.3"
-    es-errors: "npm:^1.3.0"
-    punycode: "npm:^1.4.1"
-    safe-regex-test: "npm:^1.1.0"
-  checksum: 10c0/83673cc952bb1ca01473460eb4f1289448d887ef2bfcdd142bfe83cd20a794a4393b6bca543922bf1eb913d1ae0ab69ca2d2f1f6a5e9f3de6e68464b3a3b9096
   languageName: node
   linkType: hard
 
@@ -11458,17 +11389,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-parser@npm:^4.2.2":
-  version: 4.5.3
-  resolution: "fast-xml-parser@npm:4.5.3"
-  dependencies:
-    strnum: "npm:^1.1.1"
-  bin:
-    fxparser: src/cli/cli.js
-  checksum: 10c0/bf9ccadacfadc95f6e3f0e7882a380a7f219cf0a6f96575149f02cb62bf44c3b7f0daee75b8ff3847bcfd7fbcb201e402c71045936c265cf6d94b141ec4e9327
-  languageName: node
-  linkType: hard
-
 "fast-xml-parser@npm:^4.4.1":
   version: 4.5.0
   resolution: "fast-xml-parser@npm:4.5.0"
@@ -12173,20 +12093,6 @@ __metadata:
   version: 0.1.2
   resolution: "globrex@npm:0.1.2"
   checksum: 10c0/a54c029520cf58bda1d8884f72bd49b4cd74e977883268d931fd83bcbd1a9eb96d57c7dbd4ad80148fb9247467ebfb9b215630b2ed7563b2a8de02e1ff7f89d1
-  languageName: node
-  linkType: hard
-
-"google-auth-library@npm:^9.0.0":
-  version: 9.15.1
-  resolution: "google-auth-library@npm:9.15.1"
-  dependencies:
-    base64-js: "npm:^1.3.0"
-    ecdsa-sig-formatter: "npm:^1.0.11"
-    gaxios: "npm:^6.1.1"
-    gcp-metadata: "npm:^6.1.0"
-    gtoken: "npm:^7.0.0"
-    jws: "npm:^4.0.0"
-  checksum: 10c0/6eef36d9a9cb7decd11e920ee892579261c6390104b3b24d3e0f3889096673189fe2ed0ee43fd563710e2560de98e63ad5aa4967b91e7f4e69074a422d5f7b65
   languageName: node
   linkType: hard
 
@@ -14157,14 +14063,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime-db@npm:>= 1.43.0 < 2":
-  version: 1.53.0
-  resolution: "mime-db@npm:1.53.0"
-  checksum: 10c0/1dcc37ba8ed5d1c179f5c6f0837e8db19371d5f2ea3690c3c2f3fa8c3858f976851d3460b172b4dee78ebd606762cbb407aa398545fbacd539e519f858cd7bf4
-  languageName: node
-  linkType: hard
-
-"mime-types@npm:^2.0.8, mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
+"mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
@@ -15315,13 +15214,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^1.4.1":
-  version: 1.4.1
-  resolution: "punycode@npm:1.4.1"
-  checksum: 10c0/354b743320518aef36f77013be6e15da4db24c2b4f62c5f1eb0529a6ed02fbaf1cb52925785f6ab85a962f2b590d9cd5ad730b70da72b5f180e2556b8bd3ca08
-  languageName: node
-  linkType: hard
-
 "punycode@npm:^2.1.0":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
@@ -15767,16 +15659,6 @@ __metadata:
   bin:
     resolve: bin/resolve
   checksum: 10c0/78ad6edb8309a2bfb720c2c1898f7907a37f858866ce11a5974643af1203a6a6e05b2fa9c53d8064a673a447b83d42569260c306d43628bff5bb101969708355
-  languageName: node
-  linkType: hard
-
-"retry-request@npm:^6.0.0":
-  version: 6.0.0
-  resolution: "retry-request@npm:6.0.0"
-  dependencies:
-    debug: "npm:^4.1.1"
-    extend: "npm:^3.0.2"
-  checksum: 10c0/c2484bfdd2f89aea9e23e5e69bf041a7053915d4797a1456362f25dbd9a4374165d2a45b278bcc5370c4e41ac4de894e4037cc506b7364c9a2bbf8a599279b1a
   languageName: node
   linkType: hard
 
@@ -16661,13 +16543,6 @@ __metadata:
   version: 1.0.5
   resolution: "strnum@npm:1.0.5"
   checksum: 10c0/64fb8cc2effbd585a6821faa73ad97d4b553c8927e49086a162ffd2cc818787643390b89d567460a8e74300148d11ac052e21c921ef2049f2987f4b1b89a7ff1
-  languageName: node
-  linkType: hard
-
-"strnum@npm:^1.1.1":
-  version: 1.1.2
-  resolution: "strnum@npm:1.1.2"
-  checksum: 10c0/a0fce2498fa3c64ce64a40dada41beb91cabe3caefa910e467dc0518ef2ebd7e4d10f8c2202a6104f1410254cae245066c0e94e2521fb4061a5cb41831952392
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Task
- Close atls/nestjs#384

## How to verify
### Main scenario
1. Context: `@atls/nestjs-signed-url` GCS module wiring through `@atls/nestjs-gcs-client`
Action: import `GcsClientModule.register()` and inject `GcsClientFactory` into `SignedUrlModule.gcsAsync(...)`.
Expected result: `GcsSignedUrlSigner` uses the `Storage` returned by the public GCS client factory and maps write URL options to GCS `GetSignedUrlConfig`.

### Additional scenario
1. Context: shared GCS client dependency boundary
Action: typecheck and build `@atls/nestjs-signed-url` and `@atls/nestjs-gcs-client` under Node 22.
Expected result: both packages compile against the same `@google-cloud/storage` version and the signed-url package does not duplicate GCS client configuration fields.

## Proofs
- `mise x node@22.22.3 -- yarn format packages/nestjs-gcs-client/package.json packages/nestjs-signed-url/package.json packages/nestjs-signed-url/gcs/tests/module.test.ts`: passed
- `mise x node@22.22.3 -- yarn lint packages/nestjs-signed-url/gcs/tests/module.test.ts`: passed
- `mise x node@22.22.3 -- yarn typecheck packages/nestjs-signed-url`: passed
- `mise x node@22.22.3 -- yarn typecheck packages/nestjs-gcs-client`: passed
- `mise x node@22.22.3 -- yarn test unit --test-reporter=tap` from `packages/nestjs-signed-url`: 17 tests passed
- `mise x node@22.22.3 -- yarn run build` from `packages/nestjs-signed-url`: passed
- `mise x node@22.22.3 -- yarn run build` from `packages/nestjs-gcs-client`: passed
- `mise x node@22.22.3 -- yarn check`: passed
- `git diff --check`: passed
