### PR TITLE
fix(nestjs-grpc-playground): avoid playground cdn failure

### DIFF
--- a/packages/nestjs-grpc-playground/src/controllers/grpc-playground.controller.ts
+++ b/packages/nestjs-grpc-playground/src/controllers/grpc-playground.controller.ts
@@ -19,8 +19,7 @@ export class GrpcPlaygroundController {
 
   @Get()
   async index(): Promise<string> {
-    const response = await fetch(this.getJsdelivrUrl('index.html'))
-    const content = await response.text()
+    const content = await this.resolveIndexHtml()
 
     return content.replace(/\/_next/g, this.getJsdelivrUrl('_next'))
   }
@@ -32,5 +31,39 @@ export class GrpcPlaygroundController {
 
   getJsdelivrUrl(pathname: string): string {
     return `https://cdn.jsdelivr.net/npm/@atls/grpc-playground-app@${this.options.version!}/dist/${pathname}`
+  }
+
+  protected async fetchIndexHtml(): Promise<string> {
+    const response = await fetch(this.getJsdelivrUrl('index.html'))
+
+    if (!response.ok) {
+      throw new Error(`Failed to load grpc playground index: ${response.status}`)
+    }
+
+    return response.text()
+  }
+
+  private async resolveIndexHtml(): Promise<string> {
+    try {
+      return await this.fetchIndexHtml()
+    } catch {
+      return this.getFallbackIndexHtml()
+    }
+  }
+
+  private getFallbackIndexHtml(): string {
+    return [
+      '<!doctype html>',
+      '<html>',
+      '<head>',
+      '<meta charset="utf-8">',
+      '<title>gRPC Playground</title>',
+      '<style>html,body,iframe{border:0;height:100%;margin:0;width:100%;}</style>',
+      '</head>',
+      '<body>',
+      `<iframe title="gRPC Playground" src="${this.getJsdelivrUrl('index.html')}"></iframe>`,
+      '</body>',
+      '</html>',
+    ].join('\n')
   }
 }

--- a/packages/nestjs-grpc-playground/src/controllers/grpc-playground.controller.ts
+++ b/packages/nestjs-grpc-playground/src/controllers/grpc-playground.controller.ts
@@ -19,9 +19,7 @@ export class GrpcPlaygroundController {
 
   @Get()
   async index(): Promise<string> {
-    const content = await this.resolveIndexHtml()
-
-    return content.replace(/\/_next/g, this.getJsdelivrUrl('_next'))
+    return this.resolveIndexHtml()
   }
 
   @Get('/_next/static/chunks/:chunk')
@@ -45,23 +43,51 @@ export class GrpcPlaygroundController {
 
   private async resolveIndexHtml(): Promise<string> {
     try {
-      return await this.fetchIndexHtml()
+      const content = await this.fetchIndexHtml()
+
+      return this.replaceNextAssetUrls(content)
     } catch {
       return this.getFallbackIndexHtml()
     }
   }
 
+  private replaceNextAssetUrls(content: string): string {
+    return content.replace(/\/_next/g, this.getJsdelivrUrl('_next'))
+  }
+
   private getFallbackIndexHtml(): string {
+    const indexUrl = JSON.stringify(this.getJsdelivrUrl('index.html'))
+    const nextUrl = JSON.stringify(this.getJsdelivrUrl('_next'))
+
     return [
       '<!doctype html>',
       '<html>',
       '<head>',
       '<meta charset="utf-8">',
       '<title>gRPC Playground</title>',
-      '<style>html,body,iframe{border:0;height:100%;margin:0;width:100%;}</style>',
+      '<style>html,body{height:100%;margin:0;}</style>',
       '</head>',
       '<body>',
-      `<iframe title="gRPC Playground" src="${this.getJsdelivrUrl('index.html')}"></iframe>`,
+      '<script>',
+      `const indexUrl=${indexUrl}`,
+      `const nextUrl=${nextUrl}`,
+      'fetch(indexUrl)',
+      '  .then((response) => {',
+      '    if (!response.ok) {',
+      "      throw new Error('Failed to load grpc playground index: ' + response.status)",
+      '    }',
+      '',
+      '    return response.text()',
+      '  })',
+      '  .then((content) => {',
+      '    document.open()',
+      '    document.write(content.replace(/\\/_next/g, nextUrl))',
+      '    document.close()',
+      '  })',
+      '  .catch(() => {',
+      "    document.body.textContent = 'Unable to load gRPC Playground assets.'",
+      '  })',
+      '</script>',
       '</body>',
       '</html>',
     ].join('\n')

--- a/packages/nestjs-grpc-playground/src/controllers/tests/grpc-playground.controller.test.ts
+++ b/packages/nestjs-grpc-playground/src/controllers/tests/grpc-playground.controller.test.ts
@@ -1,0 +1,58 @@
+import type { GrpcPlaygroundModuleOptions } from '../../module/index.js'
+
+import assert                               from 'node:assert/strict'
+import { describe }                         from 'node:test'
+import { it }                               from 'node:test'
+
+import { GrpcPlaygroundController }         from '../grpc-playground.controller.js'
+
+const options: GrpcPlaygroundModuleOptions = {
+  version: '0.0.8',
+  options: {
+    package: [],
+    protoPath: [],
+  },
+}
+
+type IndexHtmlLoader = () => Promise<string>
+
+class TestGrpcPlaygroundController extends GrpcPlaygroundController {
+  constructor(private readonly indexHtmlLoader: IndexHtmlLoader) {
+    super(options)
+  }
+
+  protected override async fetchIndexHtml(): Promise<string> {
+    return this.indexHtmlLoader()
+  }
+}
+
+describe('GrpcPlaygroundController', () => {
+  it('rewrites static asset paths to jsdelivr urls', async () => {
+    const target = new TestGrpcPlaygroundController(
+      async () => '<script src="/_next/static/chunks/main.js"></script>'
+    )
+
+    const content = await target.index()
+
+    assert.ok(
+      content.includes(
+        'https://cdn.jsdelivr.net/npm/@atls/grpc-playground-app@0.0.8/dist/_next/static/chunks/main.js'
+      )
+    )
+  })
+
+  it('returns fallback html when jsdelivr index is unavailable', async () => {
+    const target = new TestGrpcPlaygroundController(async () => {
+      throw new Error('CDN unavailable')
+    })
+
+    const content = await target.index()
+
+    assert.ok(content.includes('<iframe'))
+    assert.ok(
+      content.includes(
+        'https://cdn.jsdelivr.net/npm/@atls/grpc-playground-app@0.0.8/dist/index.html'
+      )
+    )
+  })
+})

--- a/packages/nestjs-grpc-playground/src/controllers/tests/grpc-playground.controller.test.ts
+++ b/packages/nestjs-grpc-playground/src/controllers/tests/grpc-playground.controller.test.ts
@@ -41,18 +41,22 @@ describe('GrpcPlaygroundController', () => {
     )
   })
 
-  it('returns fallback html when jsdelivr index is unavailable', async () => {
+  it('returns rewritten fallback html when jsdelivr index is unavailable', async () => {
     const target = new TestGrpcPlaygroundController(async () => {
       throw new Error('CDN unavailable')
     })
 
     const content = await target.index()
 
-    assert.ok(content.includes('<iframe'))
+    assert.equal(content.includes('<iframe'), false)
     assert.ok(
       content.includes(
         'https://cdn.jsdelivr.net/npm/@atls/grpc-playground-app@0.0.8/dist/index.html'
       )
     )
+    assert.ok(
+      content.includes('https://cdn.jsdelivr.net/npm/@atls/grpc-playground-app@0.0.8/dist/_next')
+    )
+    assert.ok(content.includes('document.write(content.replace(/\\/_next/g, nextUrl))'))
   })
 })


### PR DESCRIPTION
## Task
- Close atls/nestjs#404

## How to verify
### Before the fix
1. Context: `GrpcPlaygroundController#index()` fetched jsdelivr `index.html` during request handling.
Action: Run the unit check when the server-side CDN fetch fails in CI.
Expected result: the playground root route should still return `200 OK`; issue #404 captured `500 Internal Server Error` instead.

### After the fix
1. Context: `GrpcPlaygroundController#index()`.
Action: `mise x node@22.22.3 -- yarn test unit packages/nestjs-grpc-playground/src/controllers/tests/grpc-playground.controller.test.ts --test-reporter=tap`
Expected result: the fallback path returns HTML instead of propagating the CDN fetch failure.

2. Context: existing grpc playground integration test.
Action: `mise x node@22.22.3 -- yarn test integration packages/nestjs-grpc-playground/integration/test/grpc-playground.test.ts --test-reporter=tap`
Expected result: the public root route still returns HTML with `200 OK`.

## Proofs
- `mise x node@22.22.3 -- yarn lint packages/nestjs-grpc-playground/src/controllers/grpc-playground.controller.ts packages/nestjs-grpc-playground/src/controllers/tests/grpc-playground.controller.test.ts`
```text
0 warnings, 0 errors
```

- `mise x node@22.22.3 -- yarn typecheck packages/nestjs-grpc-playground`
```text
11 files processed, exit 0
```

- `mise x node@22.22.3 -- yarn test unit packages/nestjs-grpc-playground/src/controllers/tests/grpc-playground.controller.test.ts --test-reporter=tap`
```text
# tests 2
# pass 2
# fail 0
```

- `mise x node@22.22.3 -- yarn test integration packages/nestjs-grpc-playground/integration/test/grpc-playground.test.ts --test-reporter=tap`
```text
# tests 1
# pass 1
# fail 0
```

- `mise x node@22.22.3 -- yarn run build` in `packages/nestjs-grpc-playground`
```text
7 files processed, exit 0
```

- pre-commit hook under `mise x node@22.22.3 -- git commit ...`
```text
format, lint, typecheck, unit test: completed
```