### PR TITLE
build(nestjs): upgrade latest packages to nest 11

### DIFF
--- a/.pnp.cjs
+++ b/.pnp.cjs
@@ -798,8 +798,8 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/nestjs-gcs-client", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#workspace:packages/nestjs-gcs-client"],\
           ["@google-cloud/storage", "npm:7.14.0"],\
-          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
           ["@types/reflect-metadata", null],\
@@ -824,8 +824,8 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/nestjs-gcs-client", "workspace:packages/nestjs-gcs-client"],\
           ["@google-cloud/storage", "npm:7.14.0"],\
-          ["@nestjs/common", "virtual:773e124e6d7d5c23e2706ffde057b7c1d13d30452fb17121aed2189489091a233a955fdd9b958f8fa713a6cdbe245c696fcd7e05eb8d3e4a938f0a00ad757325#npm:10.4.15"],\
-          ["@nestjs/core", "virtual:773e124e6d7d5c23e2706ffde057b7c1d13d30452fb17121aed2189489091a233a955fdd9b958f8fa713a6cdbe245c696fcd7e05eb8d3e4a938f0a00ad757325#npm:10.4.15"],\
+          ["@nestjs/common", "virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27"],\
           ["reflect-metadata", "npm:0.2.2"],\
           ["rxjs", "npm:7.8.1"]\
         ],\
@@ -1531,9 +1531,10 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["@atls/nestjs-oathkeeper", "workspace:packages/nestjs-oathkeeper"],\
           ["@jest/globals", "npm:29.7.0"],\
-          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/testing", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/platform-express", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/testing", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
           ["@ory/oathkeeper-client-fetch", "npm:26.2.0"],\
           ["@types/node", "npm:22.20.0"],\
           ["reflect-metadata", "npm:0.2.2"],\
@@ -1614,8 +1615,8 @@ const RAW_RUNTIME_STATE =
           ["@aws-sdk/credential-providers", "npm:3.651.1"],\
           ["@aws-sdk/s3-request-presigner", "npm:3.651.1"],\
           ["@aws-sdk/types", "npm:3.649.0"],\
-          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
           ["@types/reflect-metadata", null],\
@@ -1643,8 +1644,8 @@ const RAW_RUNTIME_STATE =
           ["@aws-sdk/credential-providers", "npm:3.651.1"],\
           ["@aws-sdk/s3-request-presigner", "npm:3.651.1"],\
           ["@aws-sdk/types", "npm:3.649.0"],\
-          ["@nestjs/common", "virtual:6c9dc9bccc9e9b135b3d207eb5492c0f611804f454a654b42d7f16642b9765843f2a78588b253925b98b198c823be1ececbcab5059503f1d6d4d7effc5de65b3#npm:10.4.3"],\
-          ["@nestjs/core", "virtual:6c9dc9bccc9e9b135b3d207eb5492c0f611804f454a654b42d7f16642b9765843f2a78588b253925b98b198c823be1ececbcab5059503f1d6d4d7effc5de65b3#npm:10.4.3"],\
+          ["@nestjs/common", "virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27"],\
           ["reflect-metadata", "npm:0.2.2"],\
           ["rxjs", "npm:7.8.1"]\
         ],\
@@ -1660,9 +1661,10 @@ const RAW_RUNTIME_STATE =
           ["@atls/nestjs-signed-url", "workspace:packages/nestjs-signed-url"],\
           ["@google-cloud/storage", "npm:7.14.0"],\
           ["@jest/globals", "npm:29.7.0"],\
-          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/testing", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@nestjs/platform-express", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@nestjs/testing", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
           ["@types/node", "npm:22.20.0"],\
           ["reflect-metadata", "npm:0.2.2"],\
           ["rxjs", "npm:7.8.2"],\
@@ -7774,13 +7776,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["npm:10.4.22", {\
-        "packageLocation": "../.yarn/berry/cache/@nestjs-common-npm-10.4.22-982ebf7b77-10c0.zip/node_modules/@nestjs/common/",\
-        "packageDependencies": [\
-          ["@nestjs/common", "npm:10.4.22"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
       ["npm:10.4.3", {\
         "packageLocation": "../.yarn/berry/cache/@nestjs-common-npm-10.4.3-c8baed1848-10c0.zip/node_modules/@nestjs/common/",\
         "packageDependencies": [\
@@ -7792,6 +7787,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/@nestjs-common-npm-10.4.6-3ec8a02cc9-10c0.zip/node_modules/@nestjs/common/",\
         "packageDependencies": [\
           ["@nestjs/common", "npm:10.4.6"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["npm:11.1.27", {\
+        "packageLocation": "../.yarn/berry/cache/@nestjs-common-npm-11.1.27-f36b77746f-10c0.zip/node_modules/@nestjs/common/",\
+        "packageDependencies": [\
+          ["@nestjs/common", "npm:11.1.27"]\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -7865,34 +7867,6 @@ const RAW_RUNTIME_STATE =
           ["reflect-metadata", "npm:0.2.2"],\
           ["rxjs", "npm:7.8.1"],\
           ["tslib", "npm:2.6.3"],\
-          ["uid", "npm:2.0.2"]\
-        ],\
-        "packagePeers": [\
-          "@types/class-transformer",\
-          "@types/class-validator",\
-          "@types/reflect-metadata",\
-          "@types/rxjs",\
-          "class-transformer",\
-          "class-validator",\
-          "reflect-metadata",\
-          "rxjs"\
-        ],\
-        "linkType": "HARD"\
-      }],\
-      ["virtual:6c9dc9bccc9e9b135b3d207eb5492c0f611804f454a654b42d7f16642b9765843f2a78588b253925b98b198c823be1ececbcab5059503f1d6d4d7effc5de65b3#npm:10.4.3", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-common-virtual-ca700bdfd8/2/.yarn/berry/cache/@nestjs-common-npm-10.4.3-c8baed1848-10c0.zip/node_modules/@nestjs/common/",\
-        "packageDependencies": [\
-          ["@nestjs/common", "virtual:6c9dc9bccc9e9b135b3d207eb5492c0f611804f454a654b42d7f16642b9765843f2a78588b253925b98b198c823be1ececbcab5059503f1d6d4d7effc5de65b3#npm:10.4.3"],\
-          ["@types/class-transformer", null],\
-          ["@types/class-validator", null],\
-          ["@types/reflect-metadata", null],\
-          ["@types/rxjs", null],\
-          ["class-transformer", null],\
-          ["class-validator", null],\
-          ["iterare", "npm:1.2.1"],\
-          ["reflect-metadata", "npm:0.2.2"],\
-          ["rxjs", "npm:7.8.1"],\
-          ["tslib", "npm:2.7.0"],\
           ["uid", "npm:2.0.2"]\
         ],\
         "packagePeers": [\
@@ -8019,18 +7993,19 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-common-virtual-ceb64b81af/2/.yarn/berry/cache/@nestjs-common-npm-10.4.22-982ebf7b77-10c0.zip/node_modules/@nestjs/common/",\
+      ["virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-common-virtual-6160dd2a72/2/.yarn/berry/cache/@nestjs-common-npm-11.1.27-f36b77746f-10c0.zip/node_modules/@nestjs/common/",\
         "packageDependencies": [\
-          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
           ["@types/class-transformer", null],\
           ["@types/class-validator", null],\
           ["@types/reflect-metadata", null],\
           ["@types/rxjs", null],\
           ["class-transformer", null],\
           ["class-validator", null],\
-          ["file-type", "npm:20.4.1"],\
+          ["file-type", "npm:21.3.4"],\
           ["iterare", "npm:1.2.1"],\
+          ["load-esm", "npm:1.0.3"],\
           ["reflect-metadata", "npm:0.2.2"],\
           ["rxjs", "npm:7.8.2"],\
           ["tslib", "npm:2.8.1"],\
@@ -8075,6 +8050,36 @@ const RAW_RUNTIME_STATE =
           "rxjs"\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-common-virtual-9ebdb688a8/2/.yarn/berry/cache/@nestjs-common-npm-11.1.27-f36b77746f-10c0.zip/node_modules/@nestjs/common/",\
+        "packageDependencies": [\
+          ["@nestjs/common", "virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27"],\
+          ["@types/class-transformer", null],\
+          ["@types/class-validator", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["class-transformer", null],\
+          ["class-validator", null],\
+          ["file-type", "npm:21.3.4"],\
+          ["iterare", "npm:1.2.1"],\
+          ["load-esm", "npm:1.0.3"],\
+          ["reflect-metadata", "npm:0.2.2"],\
+          ["rxjs", "npm:7.8.1"],\
+          ["tslib", "npm:2.8.1"],\
+          ["uid", "npm:2.0.2"]\
+        ],\
+        "packagePeers": [\
+          "@types/class-transformer",\
+          "@types/class-validator",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "class-transformer",\
+          "class-validator",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["@nestjs/core", [\
@@ -8092,13 +8097,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["npm:10.4.22", {\
-        "packageLocation": "../.yarn/berry/cache/@nestjs-core-npm-10.4.22-71c8be05ed-10c0.zip/node_modules/@nestjs/core/",\
-        "packageDependencies": [\
-          ["@nestjs/core", "npm:10.4.22"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
       ["npm:10.4.3", {\
         "packageLocation": "../.yarn/berry/cache/@nestjs-core-npm-10.4.3-60d70056b1-10c0.zip/node_modules/@nestjs/core/",\
         "packageDependencies": [\
@@ -8110,6 +8108,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/@nestjs-core-npm-10.4.6-e5763ab66a-10c0.zip/node_modules/@nestjs/core/",\
         "packageDependencies": [\
           ["@nestjs/core", "npm:10.4.6"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["npm:11.1.27", {\
+        "packageLocation": "../.yarn/berry/cache/@nestjs-core-npm-11.1.27-e777ff171f-10c0.zip/node_modules/@nestjs/core/",\
+        "packageDependencies": [\
+          ["@nestjs/core", "npm:11.1.27"]\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -8464,45 +8469,6 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:6c9dc9bccc9e9b135b3d207eb5492c0f611804f454a654b42d7f16642b9765843f2a78588b253925b98b198c823be1ececbcab5059503f1d6d4d7effc5de65b3#npm:10.4.3", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-core-virtual-00b0bdd729/2/.yarn/berry/cache/@nestjs-core-npm-10.4.3-60d70056b1-10c0.zip/node_modules/@nestjs/core/",\
-        "packageDependencies": [\
-          ["@nestjs/common", "virtual:6c9dc9bccc9e9b135b3d207eb5492c0f611804f454a654b42d7f16642b9765843f2a78588b253925b98b198c823be1ececbcab5059503f1d6d4d7effc5de65b3#npm:10.4.3"],\
-          ["@nestjs/core", "virtual:6c9dc9bccc9e9b135b3d207eb5492c0f611804f454a654b42d7f16642b9765843f2a78588b253925b98b198c823be1ececbcab5059503f1d6d4d7effc5de65b3#npm:10.4.3"],\
-          ["@nestjs/microservices", null],\
-          ["@nestjs/platform-express", null],\
-          ["@nestjs/websockets", null],\
-          ["@nuxtjs/opencollective", "npm:0.3.2"],\
-          ["@types/nestjs__common", null],\
-          ["@types/nestjs__microservices", null],\
-          ["@types/nestjs__platform-express", null],\
-          ["@types/nestjs__websockets", null],\
-          ["@types/reflect-metadata", null],\
-          ["@types/rxjs", null],\
-          ["fast-safe-stringify", "npm:2.1.1"],\
-          ["iterare", "npm:1.2.1"],\
-          ["path-to-regexp", "npm:3.3.0"],\
-          ["reflect-metadata", "npm:0.2.2"],\
-          ["rxjs", "npm:7.8.1"],\
-          ["tslib", "npm:2.7.0"],\
-          ["uid", "npm:2.0.2"]\
-        ],\
-        "packagePeers": [\
-          "@nestjs/common",\
-          "@nestjs/microservices",\
-          "@nestjs/platform-express",\
-          "@nestjs/websockets",\
-          "@types/nestjs__common",\
-          "@types/nestjs__microservices",\
-          "@types/nestjs__platform-express",\
-          "@types/nestjs__websockets",\
-          "@types/reflect-metadata",\
-          "@types/rxjs",\
-          "reflect-metadata",\
-          "rxjs"\
-        ],\
-        "linkType": "HARD"\
-      }],\
       ["virtual:773e124e6d7d5c23e2706ffde057b7c1d13d30452fb17121aed2189489091a233a955fdd9b958f8fa713a6cdbe245c696fcd7e05eb8d3e4a938f0a00ad757325#npm:10.4.15", {\
         "packageLocation": "./.yarn/__virtual__/@nestjs-core-virtual-ebe8886e16/2/.yarn/berry/cache/@nestjs-core-npm-10.4.15-47c96ddffa-10c0.zip/node_modules/@nestjs/core/",\
         "packageDependencies": [\
@@ -8698,15 +8664,14 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-core-virtual-7504c25e16/2/.yarn/berry/cache/@nestjs-core-npm-10.4.22-71c8be05ed-10c0.zip/node_modules/@nestjs/core/",\
+      ["virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-core-virtual-2c8d09fc87/2/.yarn/berry/cache/@nestjs-core-npm-11.1.27-e777ff171f-10c0.zip/node_modules/@nestjs/core/",\
         "packageDependencies": [\
-          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
           ["@nestjs/microservices", null],\
-          ["@nestjs/platform-express", null],\
+          ["@nestjs/platform-express", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
           ["@nestjs/websockets", null],\
-          ["@nuxtjs/opencollective", "npm:0.3.2"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__microservices", null],\
           ["@types/nestjs__platform-express", null],\
@@ -8715,7 +8680,7 @@ const RAW_RUNTIME_STATE =
           ["@types/rxjs", null],\
           ["fast-safe-stringify", "npm:2.1.1"],\
           ["iterare", "npm:1.2.1"],\
-          ["path-to-regexp", "npm:3.3.0"],\
+          ["path-to-regexp", "npm:8.4.2"],\
           ["reflect-metadata", "npm:0.2.2"],\
           ["rxjs", "npm:7.8.2"],\
           ["tslib", "npm:2.8.1"],\
@@ -8776,6 +8741,44 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
+      ["virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-core-virtual-040579279a/2/.yarn/berry/cache/@nestjs-core-npm-11.1.27-e777ff171f-10c0.zip/node_modules/@nestjs/core/",\
+        "packageDependencies": [\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@nestjs/microservices", null],\
+          ["@nestjs/platform-express", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@nestjs/websockets", null],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__microservices", null],\
+          ["@types/nestjs__platform-express", null],\
+          ["@types/nestjs__websockets", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["fast-safe-stringify", "npm:2.1.1"],\
+          ["iterare", "npm:1.2.1"],\
+          ["path-to-regexp", "npm:8.4.2"],\
+          ["reflect-metadata", "npm:0.2.2"],\
+          ["rxjs", "npm:7.8.2"],\
+          ["tslib", "npm:2.8.1"],\
+          ["uid", "npm:2.0.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/microservices",\
+          "@nestjs/platform-express",\
+          "@nestjs/websockets",\
+          "@types/nestjs__common",\
+          "@types/nestjs__microservices",\
+          "@types/nestjs__platform-express",\
+          "@types/nestjs__websockets",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }],\
       ["virtual:ec8981ecaea40e2febae31b46ac73d9116df8c03ad650498e32a27b7067b620948a688dd82750726a2a222ea50e5d2539eb56777a3aebd27de3e0b0824c9aa23#npm:10.4.15", {\
         "packageLocation": "./.yarn/__virtual__/@nestjs-core-virtual-31c42a0370/2/.yarn/berry/cache/@nestjs-core-npm-10.4.15-47c96ddffa-10c0.zip/node_modules/@nestjs/core/",\
         "packageDependencies": [\
@@ -8794,6 +8797,44 @@ const RAW_RUNTIME_STATE =
           ["fast-safe-stringify", "npm:2.1.1"],\
           ["iterare", "npm:1.2.1"],\
           ["path-to-regexp", "npm:3.3.0"],\
+          ["reflect-metadata", "npm:0.2.2"],\
+          ["rxjs", "npm:7.8.1"],\
+          ["tslib", "npm:2.8.1"],\
+          ["uid", "npm:2.0.2"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/microservices",\
+          "@nestjs/platform-express",\
+          "@nestjs/websockets",\
+          "@types/nestjs__common",\
+          "@types/nestjs__microservices",\
+          "@types/nestjs__platform-express",\
+          "@types/nestjs__websockets",\
+          "@types/reflect-metadata",\
+          "@types/rxjs",\
+          "reflect-metadata",\
+          "rxjs"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-core-virtual-7fef242185/2/.yarn/berry/cache/@nestjs-core-npm-11.1.27-e777ff171f-10c0.zip/node_modules/@nestjs/core/",\
+        "packageDependencies": [\
+          ["@nestjs/common", "virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:f22d44061d926dac68746c06750e80e8a6570e5c23ac2b720054f79da48321e5c691b0740cc9c064478d31d4b070ae41282bd8b6dfc53e876e2368d6a97692d9#npm:11.1.27"],\
+          ["@nestjs/microservices", null],\
+          ["@nestjs/platform-express", null],\
+          ["@nestjs/websockets", null],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__microservices", null],\
+          ["@types/nestjs__platform-express", null],\
+          ["@types/nestjs__websockets", null],\
+          ["@types/reflect-metadata", null],\
+          ["@types/rxjs", null],\
+          ["fast-safe-stringify", "npm:2.1.1"],\
+          ["iterare", "npm:1.2.1"],\
+          ["path-to-regexp", "npm:8.4.2"],\
           ["reflect-metadata", "npm:0.2.2"],\
           ["rxjs", "npm:7.8.1"],\
           ["tslib", "npm:2.8.1"],\
@@ -9892,6 +9933,13 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
+      ["npm:11.1.27", {\
+        "packageLocation": "../.yarn/berry/cache/@nestjs-platform-express-npm-11.1.27-b5c4573a20-10c0.zip/node_modules/@nestjs/platform-express/",\
+        "packageDependencies": [\
+          ["@nestjs/platform-express", "npm:11.1.27"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
       ["virtual:095bace236d8ecd40b8814fd9ba4cdf2895bf2e2db003ebed3d7dbb04dd5c36db15a52335ba85a0463393568d3c011d855728282a1b03750c53f85aa4912f9c8#npm:10.4.1", {\
         "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-bc0fce6de1/2/.yarn/berry/cache/@nestjs-platform-express-npm-10.4.1-76944971fd-10c0.zip/node_modules/@nestjs/platform-express/",\
         "packageDependencies": [\
@@ -10024,19 +10072,19 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:ad2571d598205365c2f09d2e1510fd3327769bdfeebac0bf0ddca1228cd1fba5ef4dadfbf673708748d0e5ada59dea21f3de54e414afe788a9068c4bd7d961cf#npm:10.4.1", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-b4433956e3/2/.yarn/berry/cache/@nestjs-platform-express-npm-10.4.1-76944971fd-10c0.zip/node_modules/@nestjs/platform-express/",\
+      ["virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-b6a58afb83/2/.yarn/berry/cache/@nestjs-platform-express-npm-11.1.27-b5c4573a20-10c0.zip/node_modules/@nestjs/platform-express/",\
         "packageDependencies": [\
-          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/platform-express", "virtual:ad2571d598205365c2f09d2e1510fd3327769bdfeebac0bf0ddca1228cd1fba5ef4dadfbf673708748d0e5ada59dea21f3de54e414afe788a9068c4bd7d961cf#npm:10.4.1"],\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/platform-express", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
-          ["body-parser", "npm:1.20.2"],\
-          ["cors", "npm:2.8.5"],\
-          ["express", "npm:4.19.2"],\
-          ["multer", "npm:1.4.4-lts.1"],\
-          ["tslib", "npm:2.6.3"]\
+          ["cors", "npm:2.8.6"],\
+          ["express", "npm:5.2.1"],\
+          ["multer", "npm:2.1.1"],\
+          ["path-to-regexp", "npm:8.4.2"],\
+          ["tslib", "npm:2.8.1"]\
         ],\
         "packagePeers": [\
           "@nestjs/common",\
@@ -10103,6 +10151,28 @@ const RAW_RUNTIME_STATE =
           ["express", "npm:4.19.2"],\
           ["multer", "npm:1.4.4-lts.1"],\
           ["tslib", "npm:2.6.3"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-platform-express-virtual-2fbcd0dc14/2/.yarn/berry/cache/@nestjs-platform-express-npm-11.1.27-b5c4573a20-10c0.zip/node_modules/@nestjs/platform-express/",\
+        "packageDependencies": [\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@nestjs/platform-express", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["cors", "npm:2.8.6"],\
+          ["express", "npm:5.2.1"],\
+          ["multer", "npm:2.1.1"],\
+          ["path-to-regexp", "npm:8.4.2"],\
+          ["tslib", "npm:2.8.1"]\
         ],\
         "packagePeers": [\
           "@nestjs/common",\
@@ -10216,17 +10286,17 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "SOFT"\
       }],\
-      ["npm:10.4.22", {\
-        "packageLocation": "../.yarn/berry/cache/@nestjs-testing-npm-10.4.22-89b65d87be-10c0.zip/node_modules/@nestjs/testing/",\
-        "packageDependencies": [\
-          ["@nestjs/testing", "npm:10.4.22"]\
-        ],\
-        "linkType": "SOFT"\
-      }],\
       ["npm:10.4.6", {\
         "packageLocation": "../.yarn/berry/cache/@nestjs-testing-npm-10.4.6-f7eef43a54-10c0.zip/node_modules/@nestjs/testing/",\
         "packageDependencies": [\
           ["@nestjs/testing", "npm:10.4.6"]\
+        ],\
+        "linkType": "SOFT"\
+      }],\
+      ["npm:11.1.27", {\
+        "packageLocation": "../.yarn/berry/cache/@nestjs-testing-npm-11.1.27-b2520ec8db-10c0.zip/node_modules/@nestjs/testing/",\
+        "packageDependencies": [\
+          ["@nestjs/testing", "npm:11.1.27"]\
         ],\
         "linkType": "SOFT"\
       }],\
@@ -10481,14 +10551,14 @@ const RAW_RUNTIME_STATE =
         ],\
         "linkType": "HARD"\
       }],\
-      ["virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22", {\
-        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-ad2571d598/2/.yarn/berry/cache/@nestjs-testing-npm-10.4.22-89b65d87be-10c0.zip/node_modules/@nestjs/testing/",\
+      ["virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-1764dc85a5/2/.yarn/berry/cache/@nestjs-testing-npm-11.1.27-b2520ec8db-10c0.zip/node_modules/@nestjs/testing/",\
         "packageDependencies": [\
-          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
-          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
           ["@nestjs/microservices", null],\
-          ["@nestjs/platform-express", "virtual:ad2571d598205365c2f09d2e1510fd3327769bdfeebac0bf0ddca1228cd1fba5ef4dadfbf673708748d0e5ada59dea21f3de54e414afe788a9068c4bd7d961cf#npm:10.4.1"],\
-          ["@nestjs/testing", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:10.4.22"],\
+          ["@nestjs/platform-express", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/testing", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
           ["@types/nestjs__common", null],\
           ["@types/nestjs__core", null],\
           ["@types/nestjs__microservices", null],\
@@ -10499,6 +10569,7 @@ const RAW_RUNTIME_STATE =
           "@nestjs/common",\
           "@nestjs/core",\
           "@nestjs/microservices",\
+          "@nestjs/platform-express",\
           "@types/nestjs__common",\
           "@types/nestjs__core",\
           "@types/nestjs__microservices",\
@@ -10549,6 +10620,32 @@ const RAW_RUNTIME_STATE =
           "@nestjs/common",\
           "@nestjs/core",\
           "@nestjs/microservices",\
+          "@types/nestjs__common",\
+          "@types/nestjs__core",\
+          "@types/nestjs__microservices",\
+          "@types/nestjs__platform-express"\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27", {\
+        "packageLocation": "./.yarn/__virtual__/@nestjs-testing-virtual-46f428af7e/2/.yarn/berry/cache/@nestjs-testing-npm-11.1.27-b2520ec8db-10c0.zip/node_modules/@nestjs/testing/",\
+        "packageDependencies": [\
+          ["@nestjs/common", "virtual:83716033760d780f02c2071b5a46e1318475358477151326a9d88cb45128b0ca8bdf6fefa4a5956b7511d50ca4b136ca3e83ea24bdf2ddac3a0387970c798a68#npm:11.1.27"],\
+          ["@nestjs/core", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@nestjs/microservices", null],\
+          ["@nestjs/platform-express", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@nestjs/testing", "virtual:d0811ed27bbe998f2a12c5e875d25702d790db932248e9cd4c22d3771f27ac58970cb92e039afec78356382490581bcdbffd2df919a17c38bd0c4a3bbf7bb1ea#npm:11.1.27"],\
+          ["@types/nestjs__common", null],\
+          ["@types/nestjs__core", null],\
+          ["@types/nestjs__microservices", null],\
+          ["@types/nestjs__platform-express", null],\
+          ["tslib", "npm:2.8.1"]\
+        ],\
+        "packagePeers": [\
+          "@nestjs/common",\
+          "@nestjs/core",\
+          "@nestjs/microservices",\
+          "@nestjs/platform-express",\
           "@types/nestjs__common",\
           "@types/nestjs__core",\
           "@types/nestjs__microservices",\
@@ -11908,12 +12005,11 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["@tokenizer/inflate", [\
-      ["npm:0.2.7", {\
-        "packageLocation": "../.yarn/berry/cache/@tokenizer-inflate-npm-0.2.7-1d126e1d4f-10c0.zip/node_modules/@tokenizer/inflate/",\
+      ["npm:0.4.1", {\
+        "packageLocation": "../.yarn/berry/cache/@tokenizer-inflate-npm-0.4.1-90a0f1fb5c-10c0.zip/node_modules/@tokenizer/inflate/",\
         "packageDependencies": [\
-          ["@tokenizer/inflate", "npm:0.2.7"],\
+          ["@tokenizer/inflate", "npm:0.4.1"],\
           ["debug", "virtual:7ab5ba52b9fcd6367507dafc155330170c3c55f17548a046d928befadabfd5327abcd100d7e346691e82b7d81666c3047de6cbc3ee0adedeb0cb467f8c06e66d#npm:4.4.3"],\
-          ["fflate", "npm:0.8.3"],\
           ["token-types", "npm:6.1.2"]\
         ],\
         "linkType": "HARD"\
@@ -13186,6 +13282,15 @@ const RAW_RUNTIME_STATE =
           ["accepts", "npm:1.3.8"],\
           ["mime-types", "npm:2.1.35"],\
           ["negotiator", "npm:0.6.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/accepts-npm-2.0.0-134226d1d0-10c0.zip/node_modules/accepts/",\
+        "packageDependencies": [\
+          ["accepts", "npm:2.0.0"],\
+          ["mime-types", "npm:3.0.2"],\
+          ["negotiator", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -14652,6 +14757,22 @@ const RAW_RUNTIME_STATE =
           ["unpipe", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.3.0", {\
+        "packageLocation": "../.yarn/berry/cache/body-parser-npm-2.3.0-c6f573225c-10c0.zip/node_modules/body-parser/",\
+        "packageDependencies": [\
+          ["body-parser", "npm:2.3.0"],\
+          ["bytes", "npm:3.1.2"],\
+          ["content-type", "npm:2.0.0"],\
+          ["debug", "virtual:7ab5ba52b9fcd6367507dafc155330170c3c55f17548a046d928befadabfd5327abcd100d7e346691e82b7d81666c3047de6cbc3ee0adedeb0cb467f8c06e66d#npm:4.4.3"],\
+          ["http-errors", "npm:2.0.1"],\
+          ["iconv-lite", "npm:0.7.2"],\
+          ["on-finished", "npm:2.4.1"],\
+          ["qs", "npm:6.15.3"],\
+          ["raw-body", "npm:3.0.2"],\
+          ["type-is", "npm:2.1.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["bowser", [\
@@ -15286,6 +15407,17 @@ const RAW_RUNTIME_STATE =
           ["typedarray", "npm:0.0.6"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/concat-stream-npm-2.0.0-8bb2ad5aa0-10c0.zip/node_modules/concat-stream/",\
+        "packageDependencies": [\
+          ["buffer-from", "npm:1.1.2"],\
+          ["concat-stream", "npm:2.0.0"],\
+          ["inherits", "npm:2.0.4"],\
+          ["readable-stream", "npm:3.6.2"],\
+          ["typedarray", "npm:0.0.6"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["consola", [\
@@ -15317,6 +15449,13 @@ const RAW_RUNTIME_STATE =
           ["safe-buffer", "npm:5.2.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:1.1.0", {\
+        "packageLocation": "../.yarn/berry/cache/content-disposition-npm-1.1.0-a917b04798-10c0.zip/node_modules/content-disposition/",\
+        "packageDependencies": [\
+          ["content-disposition", "npm:1.1.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["content-type", [\
@@ -15324,6 +15463,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/content-type-npm-1.0.5-3e037bf9ab-10c0.zip/node_modules/content-type/",\
         "packageDependencies": [\
           ["content-type", "npm:1.0.5"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/content-type-npm-2.0.0-c790197c3d-10c0.zip/node_modules/content-type/",\
+        "packageDependencies": [\
+          ["content-type", "npm:2.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -15358,6 +15504,13 @@ const RAW_RUNTIME_STATE =
           ["cookie", "npm:0.7.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:0.7.2", {\
+        "packageLocation": "../.yarn/berry/cache/cookie-npm-0.7.2-6ea9ee4231-10c0.zip/node_modules/cookie/",\
+        "packageDependencies": [\
+          ["cookie", "npm:0.7.2"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["cookie-signature", [\
@@ -15365,6 +15518,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/cookie-signature-npm-1.0.6-93f325f7f0-10c0.zip/node_modules/cookie-signature/",\
         "packageDependencies": [\
           ["cookie-signature", "npm:1.0.6"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:1.2.2", {\
+        "packageLocation": "../.yarn/berry/cache/cookie-signature-npm-1.2.2-8474a8ac29-10c0.zip/node_modules/cookie-signature/",\
+        "packageDependencies": [\
+          ["cookie-signature", "npm:1.2.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -15401,6 +15561,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/cors-npm-2.8.5-c9935a2d12-10c0.zip/node_modules/cors/",\
         "packageDependencies": [\
           ["cors", "npm:2.8.5"],\
+          ["object-assign", "npm:4.1.1"],\
+          ["vary", "npm:1.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.8.6", {\
+        "packageLocation": "../.yarn/berry/cache/cors-npm-2.8.6-378df681b0-10c0.zip/node_modules/cors/",\
+        "packageDependencies": [\
+          ["cors", "npm:2.8.6"],\
           ["object-assign", "npm:4.1.1"],\
           ["vary", "npm:1.1.2"]\
         ],\
@@ -17306,6 +17475,41 @@ const RAW_RUNTIME_STATE =
           ["vary", "npm:1.1.2"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:5.2.1", {\
+        "packageLocation": "../.yarn/berry/cache/express-npm-5.2.1-d1e97b99e1-10c0.zip/node_modules/express/",\
+        "packageDependencies": [\
+          ["accepts", "npm:2.0.0"],\
+          ["body-parser", "npm:2.3.0"],\
+          ["content-disposition", "npm:1.1.0"],\
+          ["content-type", "npm:1.0.5"],\
+          ["cookie", "npm:0.7.2"],\
+          ["cookie-signature", "npm:1.2.2"],\
+          ["debug", "virtual:7ab5ba52b9fcd6367507dafc155330170c3c55f17548a046d928befadabfd5327abcd100d7e346691e82b7d81666c3047de6cbc3ee0adedeb0cb467f8c06e66d#npm:4.4.3"],\
+          ["depd", "npm:2.0.0"],\
+          ["encodeurl", "npm:2.0.0"],\
+          ["escape-html", "npm:1.0.3"],\
+          ["etag", "npm:1.8.1"],\
+          ["express", "npm:5.2.1"],\
+          ["finalhandler", "npm:2.1.1"],\
+          ["fresh", "npm:2.0.0"],\
+          ["http-errors", "npm:2.0.1"],\
+          ["merge-descriptors", "npm:2.0.0"],\
+          ["mime-types", "npm:3.0.2"],\
+          ["on-finished", "npm:2.4.1"],\
+          ["once", "npm:1.4.0"],\
+          ["parseurl", "npm:1.3.3"],\
+          ["proxy-addr", "npm:2.0.7"],\
+          ["qs", "npm:6.15.3"],\
+          ["range-parser", "npm:1.3.0"],\
+          ["router", "npm:2.2.0"],\
+          ["send", "npm:1.2.1"],\
+          ["serve-static", "npm:2.2.1"],\
+          ["statuses", "npm:2.0.2"],\
+          ["type-is", "npm:2.1.0"],\
+          ["vary", "npm:1.1.2"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["extend", [\
@@ -17567,15 +17771,6 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
-    ["fflate", [\
-      ["npm:0.8.3", {\
-        "packageLocation": "../.yarn/berry/cache/fflate-npm-0.8.3-35acaff861-10c0.zip/node_modules/fflate/",\
-        "packageDependencies": [\
-          ["fflate", "npm:0.8.3"]\
-        ],\
-        "linkType": "HARD"\
-      }]\
-    ]],\
     ["file-entry-cache", [\
       ["npm:8.0.0", {\
         "packageLocation": "../.yarn/berry/cache/file-entry-cache-npm-8.0.0-5b09d19a83-10c0.zip/node_modules/file-entry-cache/",\
@@ -17587,11 +17782,11 @@ const RAW_RUNTIME_STATE =
       }]\
     ]],\
     ["file-type", [\
-      ["npm:20.4.1", {\
-        "packageLocation": "../.yarn/berry/cache/file-type-npm-20.4.1-569bfcb42b-10c0.zip/node_modules/file-type/",\
+      ["npm:21.3.4", {\
+        "packageLocation": "../.yarn/berry/cache/file-type-npm-21.3.4-180fbe3207-10c0.zip/node_modules/file-type/",\
         "packageDependencies": [\
-          ["@tokenizer/inflate", "npm:0.2.7"],\
-          ["file-type", "npm:20.4.1"],\
+          ["@tokenizer/inflate", "npm:0.4.1"],\
+          ["file-type", "npm:21.3.4"],\
           ["strtok3", "npm:10.3.5"],\
           ["token-types", "npm:6.1.2"],\
           ["uint8array-extras", "npm:1.5.0"]\
@@ -17644,6 +17839,19 @@ const RAW_RUNTIME_STATE =
           ["parseurl", "npm:1.3.3"],\
           ["statuses", "npm:2.0.1"],\
           ["unpipe", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.1.1", {\
+        "packageLocation": "../.yarn/berry/cache/finalhandler-npm-2.1.1-aff8faac6c-10c0.zip/node_modules/finalhandler/",\
+        "packageDependencies": [\
+          ["debug", "virtual:7ab5ba52b9fcd6367507dafc155330170c3c55f17548a046d928befadabfd5327abcd100d7e346691e82b7d81666c3047de6cbc3ee0adedeb0cb467f8c06e66d#npm:4.4.3"],\
+          ["encodeurl", "npm:2.0.0"],\
+          ["escape-html", "npm:1.0.3"],\
+          ["finalhandler", "npm:2.1.1"],\
+          ["on-finished", "npm:2.4.1"],\
+          ["parseurl", "npm:1.3.3"],\
+          ["statuses", "npm:2.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -17837,6 +18045,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/fresh-npm-0.5.2-ad2bb4c0a2-10c0.zip/node_modules/fresh/",\
         "packageDependencies": [\
           ["fresh", "npm:0.5.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/fresh-npm-2.0.0-b0c1795dff-10c0.zip/node_modules/fresh/",\
+        "packageDependencies": [\
+          ["fresh", "npm:2.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -18882,6 +19097,18 @@ const RAW_RUNTIME_STATE =
           ["toidentifier", "npm:1.0.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.0.1", {\
+        "packageLocation": "../.yarn/berry/cache/http-errors-npm-2.0.1-6d19ab492e-10c0.zip/node_modules/http-errors/",\
+        "packageDependencies": [\
+          ["depd", "npm:2.0.0"],\
+          ["http-errors", "npm:2.0.1"],\
+          ["inherits", "npm:2.0.4"],\
+          ["setprototypeof", "npm:1.2.0"],\
+          ["statuses", "npm:2.0.2"],\
+          ["toidentifier", "npm:1.0.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["http-proxy-agent", [\
@@ -18938,6 +19165,14 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/iconv-lite-npm-0.6.3-24b8aae27e-10c0.zip/node_modules/iconv-lite/",\
         "packageDependencies": [\
           ["iconv-lite", "npm:0.6.3"],\
+          ["safer-buffer", "npm:2.1.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:0.7.2", {\
+        "packageLocation": "../.yarn/berry/cache/iconv-lite-npm-0.7.2-716fc012a0-10c0.zip/node_modules/iconv-lite/",\
+        "packageDependencies": [\
+          ["iconv-lite", "npm:0.7.2"],\
           ["safer-buffer", "npm:2.1.2"]\
         ],\
         "linkType": "HARD"\
@@ -19410,6 +19645,15 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/is-plain-obj-npm-4.1.0-a4f2a92b44-10c0.zip/node_modules/is-plain-obj/",\
         "packageDependencies": [\
           ["is-plain-obj", "npm:4.1.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
+    ["is-promise", [\
+      ["npm:4.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/is-promise-npm-4.0.0-1e3c05420c-10c0.zip/node_modules/is-promise/",\
+        "packageDependencies": [\
+          ["is-promise", "npm:4.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20211,6 +20455,15 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["load-esm", [\
+      ["npm:1.0.3", {\
+        "packageLocation": "../.yarn/berry/cache/load-esm-npm-1.0.3-143fe6da61-10c0.zip/node_modules/load-esm/",\
+        "packageDependencies": [\
+          ["load-esm", "npm:1.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["loader-runner", [\
       ["npm:4.3.2", {\
         "packageLocation": "../.yarn/berry/cache/loader-runner-npm-4.3.2-e730ab9cab-10c0.zip/node_modules/loader-runner/",\
@@ -20538,6 +20791,13 @@ const RAW_RUNTIME_STATE =
           ["media-typer", "npm:0.3.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:1.1.0", {\
+        "packageLocation": "../.yarn/berry/cache/media-typer-npm-1.1.0-eccc8b846d-10c0.zip/node_modules/media-typer/",\
+        "packageDependencies": [\
+          ["media-typer", "npm:1.1.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["memoizerific", [\
@@ -20562,6 +20822,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/merge-descriptors-npm-1.0.3-10b44ad75c-10c0.zip/node_modules/merge-descriptors/",\
         "packageDependencies": [\
           ["merge-descriptors", "npm:1.0.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/merge-descriptors-npm-2.0.0-abd9f0b061-10c0.zip/node_modules/merge-descriptors/",\
+        "packageDependencies": [\
+          ["merge-descriptors", "npm:2.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20643,6 +20910,13 @@ const RAW_RUNTIME_STATE =
           ["mime-db", "npm:1.52.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:1.54.0", {\
+        "packageLocation": "../.yarn/berry/cache/mime-db-npm-1.54.0-82cccb9d70-10c0.zip/node_modules/mime-db/",\
+        "packageDependencies": [\
+          ["mime-db", "npm:1.54.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["mime-types", [\
@@ -20651,6 +20925,14 @@ const RAW_RUNTIME_STATE =
         "packageDependencies": [\
           ["mime-db", "npm:1.52.0"],\
           ["mime-types", "npm:2.1.35"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:3.0.2", {\
+        "packageLocation": "../.yarn/berry/cache/mime-types-npm-3.0.2-d6d24e27e8-10c0.zip/node_modules/mime-types/",\
+        "packageDependencies": [\
+          ["mime-db", "npm:1.54.0"],\
+          ["mime-types", "npm:3.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -20872,6 +21154,17 @@ const RAW_RUNTIME_STATE =
           ["xtend", "npm:4.0.2"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:2.1.1", {\
+        "packageLocation": "../.yarn/berry/cache/multer-npm-2.1.1-f8d312dc4a-10c0.zip/node_modules/multer/",\
+        "packageDependencies": [\
+          ["append-field", "npm:1.0.0"],\
+          ["busboy", "npm:1.6.0"],\
+          ["concat-stream", "npm:2.0.0"],\
+          ["multer", "npm:2.1.1"],\
+          ["type-is", "npm:1.6.18"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["mz", [\
@@ -20910,6 +21203,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/negotiator-npm-0.6.3-9d50e36171-10c0.zip/node_modules/negotiator/",\
         "packageDependencies": [\
           ["negotiator", "npm:0.6.3"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:1.0.0", {\
+        "packageLocation": "../.yarn/berry/cache/negotiator-npm-1.0.0-47d727e27e-10c0.zip/node_modules/negotiator/",\
+        "packageDependencies": [\
+          ["negotiator", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -21570,6 +21870,13 @@ const RAW_RUNTIME_STATE =
           ["path-to-regexp", "npm:3.3.0"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:8.4.2", {\
+        "packageLocation": "../.yarn/berry/cache/path-to-regexp-npm-8.4.2-5602ed344b-10c0.zip/node_modules/path-to-regexp/",\
+        "packageDependencies": [\
+          ["path-to-regexp", "npm:8.4.2"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["path-type", [\
@@ -21929,6 +22236,15 @@ const RAW_RUNTIME_STATE =
           ["side-channel", "npm:1.0.6"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:6.15.3", {\
+        "packageLocation": "../.yarn/berry/cache/qs-npm-6.15.3-47907326d2-10c0.zip/node_modules/qs/",\
+        "packageDependencies": [\
+          ["es-define-property", "npm:1.0.1"],\
+          ["qs", "npm:6.15.3"],\
+          ["side-channel", "npm:1.1.1"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["querystringify", [\
@@ -21974,6 +22290,13 @@ const RAW_RUNTIME_STATE =
           ["range-parser", "npm:1.2.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:1.3.0", {\
+        "packageLocation": "../.yarn/berry/cache/range-parser-npm-1.3.0-b4bc01b3e0-10c0.zip/node_modules/range-parser/",\
+        "packageDependencies": [\
+          ["range-parser", "npm:1.3.0"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["raw-body", [\
@@ -21995,6 +22318,17 @@ const RAW_RUNTIME_STATE =
           ["http-errors", "npm:2.0.0"],\
           ["iconv-lite", "npm:0.4.24"],\
           ["raw-body", "npm:2.5.2"],\
+          ["unpipe", "npm:1.0.0"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:3.0.2", {\
+        "packageLocation": "../.yarn/berry/cache/raw-body-npm-3.0.2-77b7ebce9c-10c0.zip/node_modules/raw-body/",\
+        "packageDependencies": [\
+          ["bytes", "npm:3.1.2"],\
+          ["http-errors", "npm:2.0.1"],\
+          ["iconv-lite", "npm:0.7.2"],\
+          ["raw-body", "npm:3.0.2"],\
           ["unpipe", "npm:1.0.0"]\
         ],\
         "linkType": "HARD"\
@@ -22395,6 +22729,20 @@ const RAW_RUNTIME_STATE =
         "linkType": "HARD"\
       }]\
     ]],\
+    ["router", [\
+      ["npm:2.2.0", {\
+        "packageLocation": "../.yarn/berry/cache/router-npm-2.2.0-745100319e-10c0.zip/node_modules/router/",\
+        "packageDependencies": [\
+          ["debug", "virtual:7ab5ba52b9fcd6367507dafc155330170c3c55f17548a046d928befadabfd5327abcd100d7e346691e82b7d81666c3047de6cbc3ee0adedeb0cb467f8c06e66d#npm:4.4.3"],\
+          ["depd", "npm:2.0.0"],\
+          ["is-promise", "npm:4.0.0"],\
+          ["parseurl", "npm:1.3.3"],\
+          ["path-to-regexp", "npm:8.4.2"],\
+          ["router", "npm:2.2.0"]\
+        ],\
+        "linkType": "HARD"\
+      }]\
+    ]],\
     ["run-parallel", [\
       ["npm:1.2.0", {\
         "packageLocation": "../.yarn/berry/cache/run-parallel-npm-1.2.0-3f47ff2034-10c0.zip/node_modules/run-parallel/",\
@@ -22601,6 +22949,24 @@ const RAW_RUNTIME_STATE =
           ["statuses", "npm:2.0.1"]\
         ],\
         "linkType": "HARD"\
+      }],\
+      ["npm:1.2.1", {\
+        "packageLocation": "../.yarn/berry/cache/send-npm-1.2.1-6d273646b4-10c0.zip/node_modules/send/",\
+        "packageDependencies": [\
+          ["debug", "virtual:7ab5ba52b9fcd6367507dafc155330170c3c55f17548a046d928befadabfd5327abcd100d7e346691e82b7d81666c3047de6cbc3ee0adedeb0cb467f8c06e66d#npm:4.4.3"],\
+          ["encodeurl", "npm:2.0.0"],\
+          ["escape-html", "npm:1.0.3"],\
+          ["etag", "npm:1.8.1"],\
+          ["fresh", "npm:2.0.0"],\
+          ["http-errors", "npm:2.0.1"],\
+          ["mime-types", "npm:3.0.2"],\
+          ["ms", "npm:2.1.3"],\
+          ["on-finished", "npm:2.4.1"],\
+          ["range-parser", "npm:1.3.0"],\
+          ["send", "npm:1.2.1"],\
+          ["statuses", "npm:2.0.2"]\
+        ],\
+        "linkType": "HARD"\
       }]\
     ]],\
     ["sentence-case", [\
@@ -22635,6 +23001,17 @@ const RAW_RUNTIME_STATE =
           ["parseurl", "npm:1.3.3"],\
           ["send", "npm:0.19.0"],\
           ["serve-static", "npm:1.16.2"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.2.1", {\
+        "packageLocation": "../.yarn/berry/cache/serve-static-npm-2.2.1-14d79c9d45-10c0.zip/node_modules/serve-static/",\
+        "packageDependencies": [\
+          ["encodeurl", "npm:2.0.0"],\
+          ["escape-html", "npm:1.0.3"],\
+          ["parseurl", "npm:1.3.3"],\
+          ["send", "npm:1.2.1"],\
+          ["serve-static", "npm:2.2.1"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -23032,6 +23409,13 @@ const RAW_RUNTIME_STATE =
         "packageLocation": "../.yarn/berry/cache/statuses-npm-2.0.1-81d2b97fee-10c0.zip/node_modules/statuses/",\
         "packageDependencies": [\
           ["statuses", "npm:2.0.1"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.0.2", {\
+        "packageLocation": "../.yarn/berry/cache/statuses-npm-2.0.2-2d84c63b8c-10c0.zip/node_modules/statuses/",\
+        "packageDependencies": [\
+          ["statuses", "npm:2.0.2"]\
         ],\
         "linkType": "HARD"\
       }]\
@@ -24095,6 +24479,16 @@ const RAW_RUNTIME_STATE =
           ["media-typer", "npm:0.3.0"],\
           ["mime-types", "npm:2.1.35"],\
           ["type-is", "npm:1.6.18"]\
+        ],\
+        "linkType": "HARD"\
+      }],\
+      ["npm:2.1.0", {\
+        "packageLocation": "../.yarn/berry/cache/type-is-npm-2.1.0-fff4b7485f-10c0.zip/node_modules/type-is/",\
+        "packageDependencies": [\
+          ["content-type", "npm:2.0.0"],\
+          ["media-typer", "npm:1.1.0"],\
+          ["mime-types", "npm:3.0.2"],\
+          ["type-is", "npm:2.1.0"]\
         ],\
         "linkType": "HARD"\
       }]\

--- a/packages/nestjs-gcs-client/package.json
+++ b/packages/nestjs-gcs-client/package.json
@@ -20,14 +20,14 @@
     "@google-cloud/storage": "7.14.0"
   },
   "devDependencies": {
-    "@nestjs/common": "10.4.15",
-    "@nestjs/core": "10.4.15",
+    "@nestjs/common": "11.1.27",
+    "@nestjs/core": "11.1.27",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.1"
   },
   "peerDependencies": {
-    "@nestjs/common": "^10",
-    "@nestjs/core": "^10",
+    "@nestjs/common": "11",
+    "@nestjs/core": "11",
     "reflect-metadata": "^0.2",
     "rxjs": "^7"
   },

--- a/packages/nestjs-oathkeeper/package.json
+++ b/packages/nestjs-oathkeeper/package.json
@@ -22,17 +22,18 @@
   },
   "devDependencies": {
     "@jest/globals": "29.7.0",
-    "@nestjs/common": "10.4.22",
-    "@nestjs/core": "10.4.22",
-    "@nestjs/testing": "10.4.22",
+    "@nestjs/common": "11.1.27",
+    "@nestjs/core": "11.1.27",
+    "@nestjs/platform-express": "11.1.27",
+    "@nestjs/testing": "11.1.27",
     "@types/node": "22.20.0",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "typescript": "5.9.3"
   },
   "peerDependencies": {
-    "@nestjs/common": "10",
-    "@nestjs/core": "10",
+    "@nestjs/common": "11",
+    "@nestjs/core": "11",
     "reflect-metadata": "0.2",
     "rxjs": "7"
   },

--- a/packages/nestjs-s3-client/package.json
+++ b/packages/nestjs-s3-client/package.json
@@ -23,14 +23,14 @@
     "@aws-sdk/types": "^3.357.0"
   },
   "devDependencies": {
-    "@nestjs/common": "^10.0.5",
-    "@nestjs/core": "^10.0.5",
+    "@nestjs/common": "11.1.27",
+    "@nestjs/core": "11.1.27",
     "reflect-metadata": "0.2.2",
     "rxjs": "^7.8.1"
   },
   "peerDependencies": {
-    "@nestjs/common": "^10",
-    "@nestjs/core": "^10",
+    "@nestjs/common": "11",
+    "@nestjs/core": "11",
     "reflect-metadata": "^0.2",
     "rxjs": "^7"
   },

--- a/packages/nestjs-signed-url/package.json
+++ b/packages/nestjs-signed-url/package.json
@@ -24,17 +24,18 @@
     "@atls/nestjs-gcs-client": "workspace:*",
     "@google-cloud/storage": "7.14.0",
     "@jest/globals": "29.7.0",
-    "@nestjs/common": "10.4.22",
-    "@nestjs/core": "10.4.22",
-    "@nestjs/testing": "10.4.22",
+    "@nestjs/common": "11.1.27",
+    "@nestjs/core": "11.1.27",
+    "@nestjs/platform-express": "11.1.27",
+    "@nestjs/testing": "11.1.27",
     "@types/node": "22.20.0",
     "reflect-metadata": "0.2.2",
     "rxjs": "7.8.2",
     "typescript": "5.9.3"
   },
   "peerDependencies": {
-    "@nestjs/common": "10",
-    "@nestjs/core": "10",
+    "@nestjs/common": "11",
+    "@nestjs/core": "11",
     "reflect-metadata": "0.2",
     "rxjs": "7"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,13 +527,13 @@ __metadata:
   resolution: "@atls/nestjs-gcs-client@workspace:packages/nestjs-gcs-client"
   dependencies:
     "@google-cloud/storage": "npm:7.14.0"
-    "@nestjs/common": "npm:10.4.15"
-    "@nestjs/core": "npm:10.4.15"
+    "@nestjs/common": "npm:11.1.27"
+    "@nestjs/core": "npm:11.1.27"
     reflect-metadata: "npm:0.2.2"
     rxjs: "npm:7.8.1"
   peerDependencies:
-    "@nestjs/common": ^10
-    "@nestjs/core": ^10
+    "@nestjs/common": 11
+    "@nestjs/core": 11
     reflect-metadata: ^0.2
     rxjs: ^7
   languageName: unknown
@@ -900,17 +900,18 @@ __metadata:
   resolution: "@atls/nestjs-oathkeeper@workspace:packages/nestjs-oathkeeper"
   dependencies:
     "@jest/globals": "npm:29.7.0"
-    "@nestjs/common": "npm:10.4.22"
-    "@nestjs/core": "npm:10.4.22"
-    "@nestjs/testing": "npm:10.4.22"
+    "@nestjs/common": "npm:11.1.27"
+    "@nestjs/core": "npm:11.1.27"
+    "@nestjs/platform-express": "npm:11.1.27"
+    "@nestjs/testing": "npm:11.1.27"
     "@ory/oathkeeper-client-fetch": "npm:26.2.0"
     "@types/node": "npm:22.20.0"
     reflect-metadata: "npm:0.2.2"
     rxjs: "npm:7.8.2"
     typescript: "npm:5.9.3"
   peerDependencies:
-    "@nestjs/common": 10
-    "@nestjs/core": 10
+    "@nestjs/common": 11
+    "@nestjs/core": 11
     reflect-metadata: 0.2
     rxjs: 7
   languageName: unknown
@@ -963,13 +964,13 @@ __metadata:
     "@aws-sdk/credential-providers": "npm:^3.363.0"
     "@aws-sdk/s3-request-presigner": "npm:^3.363.0"
     "@aws-sdk/types": "npm:^3.357.0"
-    "@nestjs/common": "npm:^10.0.5"
-    "@nestjs/core": "npm:^10.0.5"
+    "@nestjs/common": "npm:11.1.27"
+    "@nestjs/core": "npm:11.1.27"
     reflect-metadata: "npm:0.2.2"
     rxjs: "npm:^7.8.1"
   peerDependencies:
-    "@nestjs/common": ^10
-    "@nestjs/core": ^10
+    "@nestjs/common": 11
+    "@nestjs/core": 11
     reflect-metadata: ^0.2
     rxjs: ^7
   languageName: unknown
@@ -983,16 +984,17 @@ __metadata:
     "@atls/nestjs-s3-client": "workspace:*"
     "@google-cloud/storage": "npm:7.14.0"
     "@jest/globals": "npm:29.7.0"
-    "@nestjs/common": "npm:10.4.22"
-    "@nestjs/core": "npm:10.4.22"
-    "@nestjs/testing": "npm:10.4.22"
+    "@nestjs/common": "npm:11.1.27"
+    "@nestjs/core": "npm:11.1.27"
+    "@nestjs/platform-express": "npm:11.1.27"
+    "@nestjs/testing": "npm:11.1.27"
     "@types/node": "npm:22.20.0"
     reflect-metadata: "npm:0.2.2"
     rxjs: "npm:7.8.2"
     typescript: "npm:5.9.3"
   peerDependencies:
-    "@nestjs/common": 10
-    "@nestjs/core": 10
+    "@nestjs/common": 11
+    "@nestjs/core": 11
     reflect-metadata: 0.2
     rxjs: 7
   languageName: unknown
@@ -5162,28 +5164,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/common@npm:10.4.22":
-  version: 10.4.22
-  resolution: "@nestjs/common@npm:10.4.22"
-  dependencies:
-    file-type: "npm:20.4.1"
-    iterare: "npm:1.2.1"
-    tslib: "npm:2.8.1"
-    uid: "npm:2.0.2"
-  peerDependencies:
-    class-transformer: "*"
-    class-validator: "*"
-    reflect-metadata: ^0.1.12 || ^0.2.0
-    rxjs: ^7.1.0
-  peerDependenciesMeta:
-    class-transformer:
-      optional: true
-    class-validator:
-      optional: true
-  checksum: 10c0/6b31315b173361af069ef7b79023f25eb1b8c0ed95cf453339b69a967c923961e56b2976493421ff7f055feb46f500ed42497dcf7c9a599731c9cf4c504e84d7
-  languageName: node
-  linkType: hard
-
 "@nestjs/common@npm:10.4.6":
   version: 10.4.6
   resolution: "@nestjs/common@npm:10.4.6"
@@ -5202,6 +5182,29 @@ __metadata:
     class-validator:
       optional: true
   checksum: 10c0/8bfa30ffbca605ae5b5c1b79d0fc6f9edc3b4538880e083dcde7a6e6ae5721d4bd64212a768eb9d921be878da7098e2ca2da390eedb97e4b3a724dfb6039d9e7
+  languageName: node
+  linkType: hard
+
+"@nestjs/common@npm:11.1.27":
+  version: 11.1.27
+  resolution: "@nestjs/common@npm:11.1.27"
+  dependencies:
+    file-type: "npm:21.3.4"
+    iterare: "npm:1.2.1"
+    load-esm: "npm:1.0.3"
+    tslib: "npm:2.8.1"
+    uid: "npm:2.0.2"
+  peerDependencies:
+    class-transformer: ">=0.4.1"
+    class-validator: ">=0.13.2"
+    reflect-metadata: ^0.1.12 || ^0.2.0
+    rxjs: ^7.1.0
+  peerDependenciesMeta:
+    class-transformer:
+      optional: true
+    class-validator:
+      optional: true
+  checksum: 10c0/c8c9c4ae913f302d76007ad9488c2dbf895df48373f3d9a475e7444232bd2b0d2d499557548fec48b3c38c399422456a475f8e23f79b14f3e7e46f8866d97ec0
   languageName: node
   linkType: hard
 
@@ -5282,34 +5285,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/core@npm:10.4.22":
-  version: 10.4.22
-  resolution: "@nestjs/core@npm:10.4.22"
-  dependencies:
-    "@nuxtjs/opencollective": "npm:0.3.2"
-    fast-safe-stringify: "npm:2.1.1"
-    iterare: "npm:1.2.1"
-    path-to-regexp: "npm:3.3.0"
-    tslib: "npm:2.8.1"
-    uid: "npm:2.0.2"
-  peerDependencies:
-    "@nestjs/common": ^10.0.0
-    "@nestjs/microservices": ^10.0.0
-    "@nestjs/platform-express": ^10.0.0
-    "@nestjs/websockets": ^10.0.0
-    reflect-metadata: ^0.1.12 || ^0.2.0
-    rxjs: ^7.1.0
-  peerDependenciesMeta:
-    "@nestjs/microservices":
-      optional: true
-    "@nestjs/platform-express":
-      optional: true
-    "@nestjs/websockets":
-      optional: true
-  checksum: 10c0/026393ca7d09bc80f2a2b2f0813092a9af964f2f4ecfc6a01a6cc89e8dfd107d0df8c839d373c53a9b300db954b81ed2967a56dc289785d98d897090ca66268e
-  languageName: node
-  linkType: hard
-
 "@nestjs/core@npm:10.4.6":
   version: 10.4.6
   resolution: "@nestjs/core@npm:10.4.6"
@@ -5335,6 +5310,33 @@ __metadata:
     "@nestjs/websockets":
       optional: true
   checksum: 10c0/7d43f0863799cbda52e616be9102af67363ceb3f56c69678be77630298ae09e1e0f92cef95d785f185262c2e00f80fd456f8df1328949417068b437a8fee04c1
+  languageName: node
+  linkType: hard
+
+"@nestjs/core@npm:11.1.27":
+  version: 11.1.27
+  resolution: "@nestjs/core@npm:11.1.27"
+  dependencies:
+    fast-safe-stringify: "npm:2.1.1"
+    iterare: "npm:1.2.1"
+    path-to-regexp: "npm:8.4.2"
+    tslib: "npm:2.8.1"
+    uid: "npm:2.0.2"
+  peerDependencies:
+    "@nestjs/common": ^11.0.0
+    "@nestjs/microservices": ^11.0.0
+    "@nestjs/platform-express": ^11.0.0
+    "@nestjs/websockets": ^11.0.0
+    reflect-metadata: ^0.1.12 || ^0.2.0
+    rxjs: ^7.1.0
+  peerDependenciesMeta:
+    "@nestjs/microservices":
+      optional: true
+    "@nestjs/platform-express":
+      optional: true
+    "@nestjs/websockets":
+      optional: true
+  checksum: 10c0/ac70ec5777bd93db85ba640dd952e8fd903162a71aa35f3aac99e33b1f5d87f17a317861dd7c060ee739c6252f38745a6991c713e15ca3cd354e27b036ad1e2d
   languageName: node
   linkType: hard
 
@@ -5671,6 +5673,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@nestjs/platform-express@npm:11.1.27":
+  version: 11.1.27
+  resolution: "@nestjs/platform-express@npm:11.1.27"
+  dependencies:
+    cors: "npm:2.8.6"
+    express: "npm:5.2.1"
+    multer: "npm:2.1.1"
+    path-to-regexp: "npm:8.4.2"
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    "@nestjs/common": ^11.0.0
+    "@nestjs/core": ^11.0.0
+  checksum: 10c0/81c14e49fd00fbbd8fc20250851b574a1c22a5d2af025c23655b295f013b2a6ebc166f4845bc89b765b7968f0727731bcd99fa9e7ff7b50265e282ddf8953fc0
+  languageName: node
+  linkType: hard
+
 "@nestjs/testing@npm:10.4.1":
   version: 10.4.1
   resolution: "@nestjs/testing@npm:10.4.1"
@@ -5709,25 +5727,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nestjs/testing@npm:10.4.22":
-  version: 10.4.22
-  resolution: "@nestjs/testing@npm:10.4.22"
-  dependencies:
-    tslib: "npm:2.8.1"
-  peerDependencies:
-    "@nestjs/common": ^10.0.0
-    "@nestjs/core": ^10.0.0
-    "@nestjs/microservices": ^10.0.0
-    "@nestjs/platform-express": ^10.0.0
-  peerDependenciesMeta:
-    "@nestjs/microservices":
-      optional: true
-    "@nestjs/platform-express":
-      optional: true
-  checksum: 10c0/cb3d0f3997b1c08ef7263f25beff0f0ba8af9f718361cede5c2b0a72ec0c3baadba8fcc92ec18c735171550b9e950c9e66b43e81ea62273c1ca6c82aa54e9715
-  languageName: node
-  linkType: hard
-
 "@nestjs/testing@npm:10.4.6":
   version: 10.4.6
   resolution: "@nestjs/testing@npm:10.4.6"
@@ -5744,6 +5743,25 @@ __metadata:
     "@nestjs/platform-express":
       optional: true
   checksum: 10c0/929245ed047ec152dcf938dd7ff20ce5454c798c36fc4c3f90f8729875142b87f319778355d796d1cd6751e643e324485124a4a29552025db7f678402d6b8aed
+  languageName: node
+  linkType: hard
+
+"@nestjs/testing@npm:11.1.27":
+  version: 11.1.27
+  resolution: "@nestjs/testing@npm:11.1.27"
+  dependencies:
+    tslib: "npm:2.8.1"
+  peerDependencies:
+    "@nestjs/common": ^11.0.0
+    "@nestjs/core": ^11.0.0
+    "@nestjs/microservices": ^11.0.0
+    "@nestjs/platform-express": ^11.0.0
+  peerDependenciesMeta:
+    "@nestjs/microservices":
+      optional: true
+    "@nestjs/platform-express":
+      optional: true
+  checksum: 10c0/28a8b082ac447d4e808d0e1bc5289da416f4269f6af68eedf9c5004873e56f8e7a7cb738350c144399b6c2a0ffc73a4c99c6c2a4c82b968047569f316b08a3bc
   languageName: node
   linkType: hard
 
@@ -6747,14 +6765,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tokenizer/inflate@npm:^0.2.6":
-  version: 0.2.7
-  resolution: "@tokenizer/inflate@npm:0.2.7"
+"@tokenizer/inflate@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@tokenizer/inflate@npm:0.4.1"
   dependencies:
-    debug: "npm:^4.4.0"
-    fflate: "npm:^0.8.2"
-    token-types: "npm:^6.0.0"
-  checksum: 10c0/75bd0c510810dfd62be9d963216b5852cde021e1f8aab43b37662bc6aa75e65fd7277fcab7d463186b55cee36a5b61129916161bdb2a7d18064016156c7daf4f
+    debug: "npm:^4.4.3"
+    token-types: "npm:^6.1.1"
+  checksum: 10c0/9817516efe21d1ce3bdfb80a1f94efc8981064ce3873448ba79f4d81d96c0694c484c289bd042d346ae5536cf77f5aa9a367d39c3df700eb610761b7c306b4de
   languageName: node
   linkType: hard
 
@@ -7784,6 +7801,16 @@ __metadata:
     mime-types: "npm:~2.1.34"
     negotiator: "npm:0.6.3"
   checksum: 10c0/3a35c5f5586cfb9a21163ca47a5f77ac34fa8ceb5d17d2fa2c0d81f41cbd7f8c6fa52c77e2c039acc0f4d09e71abdc51144246900f6bef5e3c4b333f77d89362
+  languageName: node
+  linkType: hard
+
+"accepts@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "accepts@npm:2.0.0"
+  dependencies:
+    mime-types: "npm:^3.0.0"
+    negotiator: "npm:^1.0.0"
+  checksum: 10c0/98374742097e140891546076215f90c32644feacf652db48412329de4c2a529178a81aa500fbb13dd3e6cbf6e68d829037b123ac037fc9a08bcec4b87b358eef
   languageName: node
   linkType: hard
 
@@ -8960,6 +8987,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"body-parser@npm:^2.2.1":
+  version: 2.3.0
+  resolution: "body-parser@npm:2.3.0"
+  dependencies:
+    bytes: "npm:^3.1.2"
+    content-type: "npm:^2.0.0"
+    debug: "npm:^4.4.3"
+    http-errors: "npm:^2.0.1"
+    iconv-lite: "npm:^0.7.2"
+    on-finished: "npm:^2.4.1"
+    qs: "npm:^6.15.2"
+    raw-body: "npm:^3.0.2"
+    type-is: "npm:^2.1.0"
+  checksum: 10c0/2a8fbbdc471b588338555a3e1a597d1eb0ad0c21cf20fdc3bac5d3f8d9c3a4b19b4163575ab852a43a5dfc0df7770ced5284f979e561f1a24c2f851ce89e695a
+  languageName: node
+  linkType: hard
+
 "bowser@npm:^2.11.0":
   version: 2.11.0
   resolution: "bowser@npm:2.11.0"
@@ -9134,7 +9178,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bytes@npm:3.1.2":
+"bytes@npm:3.1.2, bytes@npm:^3.1.2, bytes@npm:~3.1.2":
   version: 3.1.2
   resolution: "bytes@npm:3.1.2"
   checksum: 10c0/76d1c43cbd602794ad8ad2ae94095cddeb1de78c5dddaa7005c51af10b0176c69971a6d88e805a90c2b6550d76636e43c40d8427a808b8645ede885de4a0358e
@@ -9540,6 +9584,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"concat-stream@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "concat-stream@npm:2.0.0"
+  dependencies:
+    buffer-from: "npm:^1.0.0"
+    inherits: "npm:^2.0.3"
+    readable-stream: "npm:^3.0.2"
+    typedarray: "npm:^0.0.6"
+  checksum: 10c0/29565dd9198fe1d8cf57f6cc71527dbc6ad67e12e4ac9401feb389c53042b2dceedf47034cbe702dfc4fd8df3ae7e6bfeeebe732cc4fa2674e484c13f04c219a
+  languageName: node
+  linkType: hard
+
 "consola@npm:^2.15.0":
   version: 2.15.3
   resolution: "consola@npm:2.15.3"
@@ -9567,10 +9623,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:~1.0.4, content-type@npm:~1.0.5":
+"content-disposition@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "content-disposition@npm:1.1.0"
+  checksum: 10c0/94e0aef65873e69330f5f187fbc44ebce593bdcb8013dd8a68b7d0f159ca089bd30db3f8095d829f81c341695b60a6085ee6e15e6d775c4a325b586cc8d91974
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^1.0.5, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 10c0/b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
+  languageName: node
+  linkType: hard
+
+"content-type@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "content-type@npm:2.0.0"
+  checksum: 10c0/491539fff707d7594b0ca4fabcc084bef2a31ffa754ff0a4f80c4377e3963cff0394317f9271c24087596c97fa675bc123d61fa34ffe65b4904e7d3d3098de72
   languageName: node
   linkType: hard
 
@@ -9585,6 +9655,13 @@ __metadata:
   version: 1.0.6
   resolution: "cookie-signature@npm:1.0.6"
   checksum: 10c0/b36fd0d4e3fef8456915fcf7742e58fbfcc12a17a018e0eb9501c9d5ef6893b596466f03b0564b81af29ff2538fd0aa4b9d54fe5ccbfb4c90ea50ad29fe2d221
+  languageName: node
+  linkType: hard
+
+"cookie-signature@npm:^1.2.1":
+  version: 1.2.2
+  resolution: "cookie-signature@npm:1.2.2"
+  checksum: 10c0/54e05df1a293b3ce81589b27dddc445f462f6fa6812147c033350cd3561a42bc14481674e05ed14c7bd0ce1e8bb3dc0e40851bad75415733711294ddce0b7bc6
   languageName: node
   linkType: hard
 
@@ -9606,6 +9683,13 @@ __metadata:
   version: 0.7.1
   resolution: "cookie@npm:0.7.1"
   checksum: 10c0/5de60c67a410e7c8dc8a46a4b72eb0fe925871d057c9a5d2c0e8145c4270a4f81076de83410c4d397179744b478e33cd80ccbcc457abf40a9409ad27dcd21dde
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^0.7.1":
+  version: 0.7.2
+  resolution: "cookie@npm:0.7.2"
+  checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
   languageName: node
   linkType: hard
 
@@ -9637,6 +9721,16 @@ __metadata:
     object-assign: "npm:^4"
     vary: "npm:^1"
   checksum: 10c0/373702b7999409922da80de4a61938aabba6929aea5b6fd9096fefb9e8342f626c0ebd7507b0e8b0b311380744cc985f27edebc0a26e0ddb784b54e1085de761
+  languageName: node
+  linkType: hard
+
+"cors@npm:2.8.6":
+  version: 2.8.6
+  resolution: "cors@npm:2.8.6"
+  dependencies:
+    object-assign: "npm:^4"
+    vary: "npm:^1"
+  checksum: 10c0/ab2bc57b8af8ef8476682a59647f7c55c1a7d406b559ac06119aa1c5f70b96d35036864d197b24cf86e228e4547231088f1f94ca05061dbb14d89cc0bc9d4cab
   languageName: node
   linkType: hard
 
@@ -9955,7 +10049,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:^4.3.2, debug@npm:^4.4.0":
+"debug@npm:^4.3.2, debug@npm:^4.4.0, debug@npm:^4.4.3":
   version: 4.4.3
   resolution: "debug@npm:4.4.3"
   dependencies:
@@ -10024,7 +10118,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"depd@npm:2.0.0":
+"depd@npm:2.0.0, depd@npm:^2.0.0, depd@npm:~2.0.0":
   version: 2.0.0
   resolution: "depd@npm:2.0.0"
   checksum: 10c0/58bd06ec20e19529b06f7ad07ddab60e504d9e0faca4bd23079fac2d279c3594334d736508dc350e06e510aba5e22e4594483b3a6562ce7c17dd797f4cc4ad2c
@@ -10293,17 +10387,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"encodeurl@npm:^2.0.0, encodeurl@npm:~2.0.0":
+  version: 2.0.0
+  resolution: "encodeurl@npm:2.0.0"
+  checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
+  languageName: node
+  linkType: hard
+
 "encodeurl@npm:~1.0.2":
   version: 1.0.2
   resolution: "encodeurl@npm:1.0.2"
   checksum: 10c0/f6c2387379a9e7c1156c1c3d4f9cb7bb11cf16dd4c1682e1f6746512564b053df5781029b6061296832b59fb22f459dbe250386d217c2f6e203601abb2ee0bec
-  languageName: node
-  linkType: hard
-
-"encodeurl@npm:~2.0.0":
-  version: 2.0.0
-  resolution: "encodeurl@npm:2.0.0"
-  checksum: 10c0/5d317306acb13e6590e28e27924c754163946a2480de11865c991a3a7eed4315cd3fba378b543ca145829569eefe9b899f3d84bb09870f675ae60bc924b01ceb
   languageName: node
   linkType: hard
 
@@ -10636,7 +10730,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escape-html@npm:~1.0.3":
+"escape-html@npm:^1.0.3, escape-html@npm:~1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
   checksum: 10c0/524c739d776b36c3d29fa08a22e03e8824e3b2fd57500e5e44ecf3cc4707c34c60f9ca0781c0e33d191f2991161504c295e98f68c78fe7baa6e57081ec6ac0a3
@@ -11027,7 +11121,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"etag@npm:~1.8.1":
+"etag@npm:^1.8.1, etag@npm:~1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 10c0/12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
@@ -11228,6 +11322,42 @@ __metadata:
     utils-merge: "npm:1.0.1"
     vary: "npm:~1.1.2"
   checksum: 10c0/38168fd0a32756600b56e6214afecf4fc79ec28eca7f7a91c2ab8d50df4f47562ca3f9dee412da7f5cea6b1a1544b33b40f9f8586dbacfbdada0fe90dbb10a1f
+  languageName: node
+  linkType: hard
+
+"express@npm:5.2.1":
+  version: 5.2.1
+  resolution: "express@npm:5.2.1"
+  dependencies:
+    accepts: "npm:^2.0.0"
+    body-parser: "npm:^2.2.1"
+    content-disposition: "npm:^1.0.0"
+    content-type: "npm:^1.0.5"
+    cookie: "npm:^0.7.1"
+    cookie-signature: "npm:^1.2.1"
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    finalhandler: "npm:^2.1.0"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.0"
+    merge-descriptors: "npm:^2.0.0"
+    mime-types: "npm:^3.0.0"
+    on-finished: "npm:^2.4.1"
+    once: "npm:^1.4.0"
+    parseurl: "npm:^1.3.3"
+    proxy-addr: "npm:^2.0.7"
+    qs: "npm:^6.14.0"
+    range-parser: "npm:^1.2.1"
+    router: "npm:^2.2.0"
+    send: "npm:^1.1.0"
+    serve-static: "npm:^2.2.0"
+    statuses: "npm:^2.0.1"
+    type-is: "npm:^2.0.1"
+    vary: "npm:^1.1.2"
+  checksum: 10c0/45e8c841ad188a41402ddcd1294901e861ee0819f632fb494f2ed344ef9c43315d294d443fb48d594e6586a3b779785120f43321417adaef8567316a55072949
   languageName: node
   linkType: hard
 
@@ -11456,13 +11586,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fflate@npm:^0.8.2":
-  version: 0.8.3
-  resolution: "fflate@npm:0.8.3"
-  checksum: 10c0/eab181ca37f5348ae76d4b6f840e0026e30220e33153289ac942222d8b9638237d486507dbcc09878d724095bd354993a2ee48bbee99c8f2c6440d4448719aa7
-  languageName: node
-  linkType: hard
-
 "file-entry-cache@npm:^8.0.0":
   version: 8.0.0
   resolution: "file-entry-cache@npm:8.0.0"
@@ -11472,15 +11595,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"file-type@npm:20.4.1":
-  version: 20.4.1
-  resolution: "file-type@npm:20.4.1"
+"file-type@npm:21.3.4":
+  version: 21.3.4
+  resolution: "file-type@npm:21.3.4"
   dependencies:
-    "@tokenizer/inflate": "npm:^0.2.6"
-    strtok3: "npm:^10.2.0"
-    token-types: "npm:^6.0.0"
+    "@tokenizer/inflate": "npm:^0.4.1"
+    strtok3: "npm:^10.3.4"
+    token-types: "npm:^6.1.1"
     uint8array-extras: "npm:^1.4.0"
-  checksum: 10c0/ae6f65e537205a9a3e07ae574de74ed5210aa78899d6478351a466f97e3f17096b93d74cb97f3fce7488bc8486a21e449ab076ec358ed06984f4a9a8f48a9f55
+  checksum: 10c0/6f15e7538c5d73f9308d2e897365d253a6647a6751bb1b0d85c78aebc02b8976afb7c6c9b3759687a064b1b3d60246e5504746b8f11e38b0d5a1b339087e00d2
   languageName: node
   linkType: hard
 
@@ -11527,6 +11650,20 @@ __metadata:
     statuses: "npm:2.0.1"
     unpipe: "npm:~1.0.0"
   checksum: 10c0/d38035831865a49b5610206a3a9a9aae4e8523cbbcd01175d0480ffbf1278c47f11d89be3ca7f617ae6d94f29cf797546a4619cd84dd109009ef33f12f69019f
+  languageName: node
+  linkType: hard
+
+"finalhandler@npm:^2.1.0":
+  version: 2.1.1
+  resolution: "finalhandler@npm:2.1.1"
+  dependencies:
+    debug: "npm:^4.4.0"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    on-finished: "npm:^2.4.1"
+    parseurl: "npm:^1.3.3"
+    statuses: "npm:^2.0.1"
+  checksum: 10c0/6bd664e21b7b2e79efcaace7d1a427169f61cce048fae68eb56290e6934e676b78e55d89f5998c5508871345bc59a61f47002dc505dc7288be68cceac1b701e2
   languageName: node
   linkType: hard
 
@@ -11691,6 +11828,13 @@ __metadata:
   version: 0.5.2
   resolution: "fresh@npm:0.5.2"
   checksum: 10c0/c6d27f3ed86cc5b601404822f31c900dd165ba63fff8152a3ef714e2012e7535027063bc67ded4cb5b3a49fa596495d46cacd9f47d6328459cf570f08b7d9e5a
+  languageName: node
+  linkType: hard
+
+"fresh@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "fresh@npm:2.0.0"
+  checksum: 10c0/0557548194cb9a809a435bf92bcfbc20c89e8b5eb38861b73ced36750437251e39a111fc3a18b98531be9dd91fe1411e4969f229dc579ec0251ce6c5d4900bbc
   languageName: node
   linkType: hard
 
@@ -12504,6 +12648,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"http-errors@npm:^2.0.0, http-errors@npm:^2.0.1, http-errors@npm:~2.0.1":
+  version: 2.0.1
+  resolution: "http-errors@npm:2.0.1"
+  dependencies:
+    depd: "npm:~2.0.0"
+    inherits: "npm:~2.0.4"
+    setprototypeof: "npm:~1.2.0"
+    statuses: "npm:~2.0.2"
+    toidentifier: "npm:~1.0.1"
+  checksum: 10c0/fb38906cef4f5c83952d97661fe14dc156cb59fe54812a42cd448fa57b5c5dfcb38a40a916957737bd6b87aab257c0648d63eb5b6a9ca9f548e105b6072712d4
+  languageName: node
+  linkType: hard
+
 "http-proxy-agent@npm:^5.0.0":
   version: 5.0.0
   resolution: "http-proxy-agent@npm:5.0.0"
@@ -12560,6 +12717,15 @@ __metadata:
   dependencies:
     safer-buffer: "npm:>= 2.1.2 < 3.0.0"
   checksum: 10c0/98102bc66b33fcf5ac044099d1257ba0b7ad5e3ccd3221f34dd508ab4070edff183276221684e1e0555b145fce0850c9f7d2b60a9fcac50fbb4ea0d6e845a3b1
+  languageName: node
+  linkType: hard
+
+"iconv-lite@npm:^0.7.2, iconv-lite@npm:~0.7.0":
+  version: 0.7.2
+  resolution: "iconv-lite@npm:0.7.2"
+  dependencies:
+    safer-buffer: "npm:>= 2.1.2 < 3.0.0"
+  checksum: 10c0/3c228920f3bd307f56bf8363706a776f4a060eb042f131cd23855ceca962951b264d0997ab38a1ad340e1c5df8499ed26e1f4f0db6b2a2ad9befaff22f14b722
   languageName: node
   linkType: hard
 
@@ -12664,7 +12830,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.1, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -12984,6 +13150,13 @@ __metadata:
   version: 4.1.0
   resolution: "is-plain-obj@npm:4.1.0"
   checksum: 10c0/32130d651d71d9564dc88ba7e6fda0e91a1010a3694648e9f4f47bb6080438140696d3e3e15c741411d712e47ac9edc1a8a9de1fe76f3487b0d90be06ac9975e
+  languageName: node
+  linkType: hard
+
+"is-promise@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "is-promise@npm:4.0.0"
+  checksum: 10c0/ebd5c672d73db781ab33ccb155fb9969d6028e37414d609b115cc534654c91ccd061821d5b987eefaa97cf4c62f0b909bb2f04db88306de26e91bfe8ddc01503
   languageName: node
   linkType: hard
 
@@ -13734,6 +13907,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"load-esm@npm:1.0.3":
+  version: 1.0.3
+  resolution: "load-esm@npm:1.0.3"
+  checksum: 10c0/285a3666a29c11f7b466bb70ee3582af32893d03ed91b68be939c656a15afd27f3683f5f8d56b52834ce2911ecf1c84e515e6048248fb5268a89b724a8ddbf65
+  languageName: node
+  linkType: hard
+
 "loader-runner@npm:^4.2.0":
   version: 4.3.2
   resolution: "loader-runner@npm:4.3.2"
@@ -14015,6 +14195,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"media-typer@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "media-typer@npm:1.1.0"
+  checksum: 10c0/7b4baa40b25964bb90e2121ee489ec38642127e48d0cc2b6baa442688d3fde6262bfdca86d6bbf6ba708784afcac168c06840c71facac70e390f5f759ac121b9
+  languageName: node
+  linkType: hard
+
 "memoizerific@npm:^1.11.3":
   version: 1.11.3
   resolution: "memoizerific@npm:1.11.3"
@@ -14035,6 +14222,13 @@ __metadata:
   version: 1.0.3
   resolution: "merge-descriptors@npm:1.0.3"
   checksum: 10c0/866b7094afd9293b5ea5dcd82d71f80e51514bed33b4c4e9f516795dc366612a4cbb4dc94356e943a8a6914889a914530badff27f397191b9b75cda20b6bae93
+  languageName: node
+  linkType: hard
+
+"merge-descriptors@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "merge-descriptors@npm:2.0.0"
+  checksum: 10c0/95389b7ced3f9b36fbdcf32eb946dc3dd1774c2fdf164609e55b18d03aa499b12bd3aae3a76c1c7185b96279e9803525550d3eb292b5224866060a288f335cb3
   languageName: node
   linkType: hard
 
@@ -14083,12 +14277,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mime-db@npm:^1.54.0":
+  version: 1.54.0
+  resolution: "mime-db@npm:1.54.0"
+  checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
 "mime-types@npm:^2.1.12, mime-types@npm:^2.1.27, mime-types@npm:~2.1.24, mime-types@npm:~2.1.34":
   version: 2.1.35
   resolution: "mime-types@npm:2.1.35"
   dependencies:
     mime-db: "npm:1.52.0"
   checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^3.0.0, mime-types@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "mime-types@npm:3.0.2"
+  dependencies:
+    mime-db: "npm:^1.54.0"
+  checksum: 10c0/35a0dd1035d14d185664f346efcdb72e93ef7a9b6e9ae808bd1f6358227010267fab52657b37562c80fc888ff76becb2b2938deb5e730818b7983bf8bd359767
   languageName: node
   linkType: hard
 
@@ -14338,6 +14548,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"multer@npm:2.1.1":
+  version: 2.1.1
+  resolution: "multer@npm:2.1.1"
+  dependencies:
+    append-field: "npm:^1.0.0"
+    busboy: "npm:^1.6.0"
+    concat-stream: "npm:^2.0.0"
+    type-is: "npm:^1.6.18"
+  checksum: 10c0/2ec4e02833b20f403cfb879d4b64d2a9070d902b9deae7aef18a6faadb707d7665385456cf540aa8a6dadfe3d4c5fc8e0e7b0675b94e1077048b1125426deee6
+  languageName: node
+  linkType: hard
+
 "mz@npm:^2.4.0":
   version: 2.7.0
   resolution: "mz@npm:2.7.0"
@@ -14369,6 +14591,13 @@ __metadata:
   version: 0.6.3
   resolution: "negotiator@npm:0.6.3"
   checksum: 10c0/3ec9fd413e7bf071c937ae60d572bc67155262068ed522cf4b3be5edbe6ddf67d095ec03a3a14ebf8fc8e95f8e1d61be4869db0dbb0de696f6b837358bd43fc2
+  languageName: node
+  linkType: hard
+
+"negotiator@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "negotiator@npm:1.0.0"
+  checksum: 10c0/4c559dd52669ea48e1914f9d634227c561221dd54734070791f999c52ed0ff36e437b2e07d5c1f6e32909fc625fe46491c16e4a8f0572567d4dd15c3a4fda04b
   languageName: node
   linkType: hard
 
@@ -14687,7 +14916,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"on-finished@npm:2.4.1":
+"on-finished@npm:2.4.1, on-finished@npm:^2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
   dependencies:
@@ -14843,7 +15072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"parseurl@npm:^1.3.2, parseurl@npm:~1.3.3":
+"parseurl@npm:^1.3.2, parseurl@npm:^1.3.3, parseurl@npm:~1.3.3":
   version: 1.3.3
   resolution: "parseurl@npm:1.3.3"
   checksum: 10c0/90dd4760d6f6174adb9f20cf0965ae12e23879b5f5464f38e92fce8073354341e4b3b76fa3d878351efe7d01e617121955284cfd002ab087fba1a0726ec0b4f5
@@ -14947,6 +15176,13 @@ __metadata:
   version: 3.3.0
   resolution: "path-to-regexp@npm:3.3.0"
   checksum: 10c0/ffa0ebe7088d38d435a8d08b0fe6e8c93ceb2a81a65d4dd1d9a538f52e09d5e3474ed5f553cb3b180d894b0caa10698a68737ab599fd1e56b4663d1a64c9f77b
+  languageName: node
+  linkType: hard
+
+"path-to-regexp@npm:8.4.2, path-to-regexp@npm:^8.0.0":
+  version: 8.4.2
+  resolution: "path-to-regexp@npm:8.4.2"
+  checksum: 10c0/05b115c49b47ad252ce05faa32930f643f23769c68b8bcfe78ad833545140c48bbffb3266986d6c8d5db13a64cf12e07e0d72d9882cab830efeefa553533ebaf
   languageName: node
   linkType: hard
 
@@ -15217,7 +15453,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-addr@npm:~2.0.7":
+"proxy-addr@npm:^2.0.7, proxy-addr@npm:~2.0.7":
   version: 2.0.7
   resolution: "proxy-addr@npm:2.0.7"
   dependencies:
@@ -15269,6 +15505,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.14.0, qs@npm:^6.15.2":
+  version: 6.15.3
+  resolution: "qs@npm:6.15.3"
+  dependencies:
+    es-define-property: "npm:^1.0.1"
+    side-channel: "npm:^1.1.1"
+  checksum: 10c0/8f3f6e45ece255347d57696628401cde29e9ec649fff698b53bd3150dea7cefdf33036e1bc1826b9f110bfa7cb0ec4ab9f5297eca628ce216c55af82c304e08e
+  languageName: node
+  linkType: hard
+
 "querystringify@npm:^2.1.1":
   version: 2.2.0
   resolution: "querystringify@npm:2.2.0"
@@ -15294,6 +15540,13 @@ __metadata:
   version: 4.0.4
   resolution: "quick-format-unescaped@npm:4.0.4"
   checksum: 10c0/fe5acc6f775b172ca5b4373df26f7e4fd347975578199e7d74b2ae4077f0af05baa27d231de1e80e8f72d88275ccc6028568a7a8c9ee5e7368ace0e18eff93a4
+  languageName: node
+  linkType: hard
+
+"range-parser@npm:^1.2.1":
+  version: 1.3.0
+  resolution: "range-parser@npm:1.3.0"
+  checksum: 10c0/295494bb6685f9ab50f41a5f4fa5ce445aeeb9673b491bf178460fcc3a812dcf0d164cf1c83074f13a71a87d91ead5e097afd53e0630bc49a5101ed60f2a7529
   languageName: node
   linkType: hard
 
@@ -15325,6 +15578,18 @@ __metadata:
     iconv-lite: "npm:0.4.24"
     unpipe: "npm:1.0.0"
   checksum: 10c0/b201c4b66049369a60e766318caff5cb3cc5a900efd89bdac431463822d976ad0670912c931fdbdcf5543207daf6f6833bca57aa116e1661d2ea91e12ca692c4
+  languageName: node
+  linkType: hard
+
+"raw-body@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "raw-body@npm:3.0.2"
+  dependencies:
+    bytes: "npm:~3.1.2"
+    http-errors: "npm:~2.0.1"
+    iconv-lite: "npm:~0.7.0"
+    unpipe: "npm:~1.0.0"
+  checksum: 10c0/d266678d08e1e7abea62c0ce5864344e980fa81c64f6b481e9842c5beaed2cdcf975f658a3ccd67ad35fc919c1f6664ccc106067801850286a6cbe101de89f29
   languageName: node
   linkType: hard
 
@@ -15417,7 +15682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
+"readable-stream@npm:^3.0.2, readable-stream@npm:^3.1.1, readable-stream@npm:^3.4.0, readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
   dependencies:
@@ -15706,6 +15971,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"router@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "router@npm:2.2.0"
+  dependencies:
+    debug: "npm:^4.4.0"
+    depd: "npm:^2.0.0"
+    is-promise: "npm:^4.0.0"
+    parseurl: "npm:^1.3.3"
+    path-to-regexp: "npm:^8.0.0"
+  checksum: 10c0/3279de7450c8eae2f6e095e9edacbdeec0abb5cb7249c6e719faa0db2dba43574b4fff5892d9220631c9abaff52dd3cad648cfea2aaace845e1a071915ac8867
+  languageName: node
+  linkType: hard
+
 "run-parallel@npm:^1.1.9":
   version: 1.2.0
   resolution: "run-parallel@npm:1.2.0"
@@ -15908,6 +16186,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"send@npm:^1.1.0, send@npm:^1.2.0":
+  version: 1.2.1
+  resolution: "send@npm:1.2.1"
+  dependencies:
+    debug: "npm:^4.4.3"
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    etag: "npm:^1.8.1"
+    fresh: "npm:^2.0.0"
+    http-errors: "npm:^2.0.1"
+    mime-types: "npm:^3.0.2"
+    ms: "npm:^2.1.3"
+    on-finished: "npm:^2.4.1"
+    range-parser: "npm:^1.2.1"
+    statuses: "npm:^2.0.2"
+  checksum: 10c0/fbbbbdc902a913d65605274be23f3d604065cfc3ee3d78bf9fc8af1dc9fc82667c50d3d657f5e601ac657bac9b396b50ee97bd29cd55436320cf1cddebdcec72
+  languageName: node
+  linkType: hard
+
 "sentence-case@npm:^3.0.4":
   version: 3.0.4
   resolution: "sentence-case@npm:3.0.4"
@@ -15940,6 +16237,18 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.19.0"
   checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
+  languageName: node
+  linkType: hard
+
+"serve-static@npm:^2.2.0":
+  version: 2.2.1
+  resolution: "serve-static@npm:2.2.1"
+  dependencies:
+    encodeurl: "npm:^2.0.0"
+    escape-html: "npm:^1.0.3"
+    parseurl: "npm:^1.3.3"
+    send: "npm:^1.2.0"
+  checksum: 10c0/37986096e8572e2dfaad35a3925fa8da0c0969f8814fd7788e84d4d388bc068cf0c06d1658509788e55bed942a6b6d040a8a267fa92bb9ffb1179f8bacde5fd7
   languageName: node
   linkType: hard
 
@@ -15980,7 +16289,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"setprototypeof@npm:1.2.0":
+"setprototypeof@npm:1.2.0, setprototypeof@npm:~1.2.0":
   version: 1.2.0
   resolution: "setprototypeof@npm:1.2.0"
   checksum: 10c0/68733173026766fa0d9ecaeb07f0483f4c2dc70ca376b3b7c40b7cda909f94b0918f6c5ad5ce27a9160bdfb475efaa9d5e705a11d8eaae18f9835d20976028bc
@@ -16062,7 +16371,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"side-channel@npm:^1.1.0":
+"side-channel@npm:^1.1.0, side-channel@npm:^1.1.1":
   version: 1.1.1
   resolution: "side-channel@npm:1.1.1"
   dependencies:
@@ -16302,6 +16611,13 @@ __metadata:
   version: 1.5.0
   resolution: "statuses@npm:1.5.0"
   checksum: 10c0/e433900956357b3efd79b1c547da4d291799ac836960c016d10a98f6a810b1b5c0dcc13b5a7aa609a58239b5190e1ea176ad9221c2157d2fd1c747393e6b2940
+  languageName: node
+  linkType: hard
+
+"statuses@npm:^2.0.1, statuses@npm:^2.0.2, statuses@npm:~2.0.2":
+  version: 2.0.2
+  resolution: "statuses@npm:2.0.2"
+  checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
   languageName: node
   linkType: hard
 
@@ -16557,7 +16873,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"strtok3@npm:^10.2.0":
+"strtok3@npm:^10.3.4":
   version: 10.3.5
   resolution: "strtok3@npm:10.3.5"
   dependencies:
@@ -16991,14 +17307,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"toidentifier@npm:1.0.1":
+"toidentifier@npm:1.0.1, toidentifier@npm:~1.0.1":
   version: 1.0.1
   resolution: "toidentifier@npm:1.0.1"
   checksum: 10c0/93937279934bd66cc3270016dd8d0afec14fb7c94a05c72dc57321f8bd1fa97e5bea6d1f7c89e728d077ca31ea125b78320a616a6c6cd0e6b9cb94cb864381c1
   languageName: node
   linkType: hard
 
-"token-types@npm:^6.0.0":
+"token-types@npm:^6.1.1":
   version: 6.1.2
   resolution: "token-types@npm:6.1.2"
   dependencies:
@@ -17204,13 +17520,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-is@npm:^1.6.16, type-is@npm:^1.6.4, type-is@npm:~1.6.18":
+"type-is@npm:^1.6.16, type-is@npm:^1.6.18, type-is@npm:^1.6.4, type-is@npm:~1.6.18":
   version: 1.6.18
   resolution: "type-is@npm:1.6.18"
   dependencies:
     media-typer: "npm:0.3.0"
     mime-types: "npm:~2.1.24"
   checksum: 10c0/a23daeb538591b7efbd61ecf06b6feb2501b683ffdc9a19c74ef5baba362b4347e42f1b4ed81f5882a8c96a3bfff7f93ce3ffaf0cbbc879b532b04c97a55db9d
+  languageName: node
+  linkType: hard
+
+"type-is@npm:^2.0.1, type-is@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "type-is@npm:2.1.0"
+  dependencies:
+    content-type: "npm:^2.0.0"
+    media-typer: "npm:^1.1.0"
+    mime-types: "npm:^3.0.0"
+  checksum: 10c0/a6018f8f509de48f2c7429305e3a920e73b374fa93127dd0877ae1c2df65a5d33907caac8afb0c37a9b9fc7c49f29e3f55d668963dc845d966930b667c07f50e
   languageName: node
   linkType: hard
 
@@ -17808,7 +18135,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vary@npm:^1, vary@npm:~1.1.2":
+"vary@npm:^1, vary@npm:^1.1.2, vary@npm:~1.1.2":
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10c0/f15d588d79f3675135ba783c91a4083dcd290a2a5be9fcb6514220a1634e23df116847b1cc51f66bfb0644cf9353b2abb7815ae499bab06e46dd33c1a6bf1f4f


### PR DESCRIPTION
## Task
- Close atls/nestjs#415

## How to verify
### Main scenario
1. Context: A Nest 11 consumer installs @atls/nestjs-signed-url, @atls/nestjs-oathkeeper, @atls/nestjs-gcs-client or @atls/nestjs-s3-client
Action: Resolve workspace dependencies after the package manifests are updated
Expected result: These packages expose Nest 11 peer contracts and do not keep Nest 10 peer requirements in the signed URL dependency chain

### Additional scenario
1. Context: The repository builds the updated packages under the repo-managed Node runtime
Action: Run format, lint, typecheck, unit tests and package builds for the affected packages
Expected result: The dependency update compiles and the existing signed-url and oathkeeper unit coverage stays green

## Proofs
- `yarn install`
- `yarn format packages/nestjs-signed-url/package.json packages/nestjs-oathkeeper/package.json packages/nestjs-gcs-client/package.json packages/nestjs-s3-client/package.json`
- `yarn lint packages/nestjs-signed-url packages/nestjs-oathkeeper packages/nestjs-gcs-client packages/nestjs-s3-client`
- `yarn typecheck packages/nestjs-signed-url packages/nestjs-oathkeeper packages/nestjs-gcs-client packages/nestjs-s3-client`
- `git diff --check -- packages/nestjs-signed-url/package.json packages/nestjs-oathkeeper/package.json packages/nestjs-gcs-client/package.json packages/nestjs-s3-client/package.json yarn.lock .pnp.cjs`
- `mise x node@22.22.3 -- yarn test unit packages/nestjs-oathkeeper/module/tests/module.test.ts packages/nestjs-oathkeeper/src/tests/decision.test.ts packages/nestjs-oathkeeper/src/tests/middleware.test.ts packages/nestjs-signed-url/gcs/tests/gateway.test.ts packages/nestjs-signed-url/gcs/tests/module.test.ts packages/nestjs-signed-url/module/tests/module.test.ts packages/nestjs-signed-url/src/tests/options.test.ts packages/nestjs-signed-url/src/tests/signer.test.ts packages/nestjs-signed-url/tests/gateway.test.ts packages/nestjs-signed-url/s3/tests/module.test.ts packages/nestjs-signed-url/s3/tests/gateway.test.ts`
- `mise x node@22.22.3 -- yarn workspace @atls/nestjs-signed-url build`
- `mise x node@22.22.3 -- yarn workspace @atls/nestjs-oathkeeper build`
- `mise x node@22.22.3 -- yarn workspace @atls/nestjs-gcs-client build`
- `mise x node@22.22.3 -- yarn workspace @atls/nestjs-s3-client build`
- pre-commit hook passed during commit
